### PR TITLE
Use (void) when declaring C functions with no parameters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ GIT_DESCRIBE ?= $(shell git describe --tags --abbrev=8 --always --long --dirty 2
 VERSION_TAG ?= $(shell echo "$(GIT_DESCRIBE)" | cut -f1 -d-)
 APPVERSION_M=0
 APPVERSION_N=2
-APPVERSION_P=0
+APPVERSION_P=1
 APPVERSION=$(APPVERSION_M).$(APPVERSION_N).$(APPVERSION_P)
 
 # Only warn about version tags if specified/inferred

--- a/src/apdu.c
+++ b/src/apdu.c
@@ -62,7 +62,7 @@ size_t handle_apdu_get_wallet_id(void) {
     uint8_t wallet_id[CX_SHA256_SIZE];
 
     bip32_path_t id_path = {2, {ROOT_PATH_0, ROOT_PATH_1}};
-    const unsigned char hmac_key[] = "wallet-id";
+    static const unsigned char hmac_key[] = "wallet-id";
 
     cx_hmac_sha256_t hmac_state;
     cx_hmac_sha256_init(&hmac_state, hmac_key, sizeof(hmac_key)-1);
@@ -78,14 +78,14 @@ size_t handle_apdu_get_wallet_id(void) {
 }
 
 #ifdef STACK_MEASURE
-__attribute__((noinline)) void stack_sentry_fill() {
+__attribute__((noinline)) void stack_sentry_fill(void) {
   uint32_t* p;
   volatile int top;
   top=5;
   memset((void*)(&app_stack_canary+1), 42, ((uint8_t*)(&top-10))-((uint8_t*)&app_stack_canary));
 }
 
-void measure_stack_max() {
+void measure_stack_max(void) {
   uint32_t* p;
   volatile int top;
   for(p=&app_stack_canary+1; p<((&top)-10); p++)

--- a/src/apdu_pubkey.c
+++ b/src/apdu_pubkey.c
@@ -29,7 +29,7 @@ static void apdu_pubkey_state_to_string
   pkh_to_string(out, out_size, payload->hrp, payload->hrp_len, &payload->pkh);
 }
 
-__attribute__((noreturn)) static void prompt_address() {
+__attribute__((noreturn)) static void prompt_address(void) {
     static size_t const TYPE_INDEX = 0;
     static size_t const ADDRESS_INDEX = 1;
     static size_t const DRV_PATH_INDEX = 2;
@@ -46,7 +46,7 @@ __attribute__((noreturn)) static void prompt_address() {
     ui_prompt(pubkey_labels, address_ok, delay_reject);
 }
 
-__attribute__((noreturn)) static void prompt_ext_pubkey() {
+__attribute__((noreturn)) static void prompt_ext_pubkey(void) {
     static size_t const TYPE_INDEX = 0;
     static size_t const DRV_PATH_INDEX = 1;
 
@@ -78,7 +78,7 @@ __attribute__((noreturn)) size_t handle_apdu_get_public_key_impl(bool const prom
     }
 
     if (p1 == 0) {
-      static const char default_hrp[] = "mainnet";
+      static const char default_hrp[] = "avax";
       G.hrp_len = sizeof(default_hrp) - 1;
       memcpy(G.hrp, default_hrp, G.hrp_len);
     } else {
@@ -99,10 +99,10 @@ __attribute__((noreturn)) size_t handle_apdu_get_public_key_impl(bool const prom
 }
 
 
-__attribute__((noreturn)) size_t handle_apdu_get_public_key() {
+__attribute__((noreturn)) size_t handle_apdu_get_public_key(void) {
     handle_apdu_get_public_key_impl(false);
 }
 
-__attribute__((noreturn)) size_t handle_apdu_get_public_key_ext() {
+__attribute__((noreturn)) size_t handle_apdu_get_public_key_ext(void) {
     handle_apdu_get_public_key_impl(true);
 }

--- a/src/globals.h
+++ b/src/globals.h
@@ -81,7 +81,7 @@ extern ux_state_t ux;
 #endif
 extern unsigned char G_io_seproxyhal_spi_buffer[IO_SEPROXYHAL_BUFFER_SIZE_B];
 
-static inline void throw_stack_size() {
+static inline void throw_stack_size(void) {
     uint8_t st;
     // uint32_t tmp1 = (uint32_t)&st - (uint32_t)&app_stack_canary;
     uint32_t tmp2 = (uint32_t)global.stack_root - (uint32_t)&st;
@@ -109,8 +109,8 @@ static inline void throw_stack_size() {
         nvm_write((void *)&N_data, &global.new_data, sizeof(N_data));                                 \
     })
 
-void switch_network();
-void switch_sign_hash();
+void switch_network(void);
+void switch_sign_hash(void);
 
 #ifdef AVA_DEBUG
 // Aid for tracking down app crashes

--- a/src/ui_nano_s.c
+++ b/src/ui_nano_s.c
@@ -290,7 +290,7 @@ static const ux_menu_entry_t main_menu_data[] = {
     {NULL, exit_app_cb, 0, NULL, "Quit app", NULL, 50, 29}, // TODO: Put icon for "dashboard" in
     UX_MENU_END};
 
-void main_menu() {
+void main_menu(void) {
     UX_MENU_DISPLAY(0, main_menu_data, NULL);
 }
 


### PR DESCRIPTION
Also bumped the point version,  updated the default HRP, and declared a
string as static const.