### PR TITLE
Add reject sign hash setting

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -9,8 +9,17 @@ __attribute__((noreturn)) void app_main(void) {
         (apdu_handler)PIC(handle_apdu_get_public_key),      // 0x02
         (apdu_handler)PIC(handle_apdu_get_public_key_ext),  // 0x03
         (apdu_handler)PIC(handle_apdu_sign_hash),           // 0x04
-        (apdu_handler)PIC(handle_apdu_sign_transaction),    // 0x05 
+        (apdu_handler)PIC(handle_apdu_sign_transaction),    // 0x05
     };
+
+    if (!N_data.initialized) {
+        nvram_data data = {
+            .initialized = true,
+            .sign_hash_policy = WARN_ON_SIGN_HASH,
+            .sign_hash_policy_prompt = "Allow with warning",
+        };
+        nvm_write((void*)&N_data, (void*)&data, sizeof(N_data));
+    }
 
     main_loop(handlers, NUM_ELEMENTS(handlers));
 }

--- a/src/types.h
+++ b/src/types.h
@@ -122,5 +122,14 @@ typedef char ascii_hrp_t[ASCII_HRP_MAX_SIZE];
         ____a_ < ____b_ ? ____a_ : ____b_;                                                                             \
     })
 
+typedef enum {
+    WARN_ON_SIGN_HASH=0,
+    DISALLOW_ON_SIGN_HASH,
+    ALLOW_ON_SIGN_HASH,
+} sign_hash_policy_t;
+
 typedef struct {
+    bool initialized;
+    sign_hash_policy_t sign_hash_policy;
+    char sign_hash_policy_prompt[20];
 } nvram_data;

--- a/src/ui_nano_s.c
+++ b/src/ui_nano_s.c
@@ -283,17 +283,31 @@ void exit_app_cb(__attribute__((unused)) unsigned int cb) {
 // Mutually recursive static variables require forward declarations
 static const ux_menu_entry_t main_menu_data[];
 static const ux_menu_entry_t about_menu_data[];
+static const ux_menu_entry_t configuration_menu_data[];
 
 static const ux_menu_entry_t about_menu_data[] = {
     {NULL, NULL, 0, NULL, "Avalanche", "Version " VERSION, 0, 0},
     {main_menu_data, NULL, 1, NULL, "Back", NULL, 61, 40}, // TODO: Put icon for "back" in
     UX_MENU_END};
 
+static const ux_menu_entry_t configuration_menu_data[] = {
+    {NULL, NULL, 0, NULL, "Avalanche", "Configuration", 0, 0},
+    {main_menu_data, NULL, 1, NULL, "Back", NULL, 61, 40}, // TODO: Put icon for "back" in
+    UX_MENU_END};
+
 static const ux_menu_entry_t main_menu_data[] = {
     {NULL, NULL, 0, NULL, "Use wallet to", "view accounts", 0, 0},
+    {configuration_menu_data, NULL, 0, NULL, "Configuration", NULL, 0, 0},
     {about_menu_data, NULL, 0, NULL, "About", NULL, 0, 0},
     {NULL, exit_app_cb, 0, NULL, "Quit app", NULL, 50, 29}, // TODO: Put icon for "dashboard" in
     UX_MENU_END};
+
+static const ux_menu_entry_t configuration_sign_hash_policy_menu_data[] = {
+  {NULL, configuration_sign_hash, WARN_ON_SIGN_HASH, NULL, "Allow with warning", NULL, 0, 0},
+  {NULL, configuration_sign_hash, DISALLOW_ON_SIGN_HASH, NULL, "Disallow", NULL, 0, 0},
+  {NULL, configuration_sign_hash, ALLOW_ON_SIGN_HASH, NULL, "Allow", NULL, 0, 0},
+  UX_MENU_END
+};
 
 void main_menu(void) {
     UX_MENU_DISPLAY(0, main_menu_data, NULL);

--- a/tests/basic-tests.js
+++ b/tests/basic-tests.js
@@ -103,6 +103,25 @@ describe("Basic Tests", () => {
       }
     });
 
+    it('rejects signing hash when disallowed in settings', async function () {
+      this.speculos.button("RrRLrlRLrlRrRLrl");
+
+      try {
+        await checkSignHash(
+          this,
+          "44'/9000'/1'",
+          ["0/0"],
+          "111122223333444455556666777788889999aaaabbbbccccddddeeeeffff0000"
+        );
+        throw "Expected failure";
+      } catch (e) {
+        expect(e).has.property('statusCode', 0x6985); // REJECT
+        expect(e).has.property('statusText', 'INCORRECT_DATA');
+      } finally {
+        this.speculos.button("RrRLrlRLrlRLrlRrRLrl");
+      }
+    });
+
     it('can sign a transaction based on the serialization reference in verbose mode', async function () {
       const pathPrefix = "44'/9000'/1'";
       const pathSuffixes = ["0/0", "0/1", "100/100"];

--- a/tests/basic-tests.js
+++ b/tests/basic-tests.js
@@ -103,24 +103,24 @@ describe("Basic Tests", () => {
       }
     });
 
-    it('rejects signing hash when disallowed in settings', async function () {
-      this.speculos.button("RrRLrlRLrlRrRLrl");
+    // it('rejects signing hash when disallowed in settings', async function () {
+    //   this.speculos.button("RrRLrlRLrlRrRLrl");
 
-      try {
-        await checkSignHash(
-          this,
-          "44'/9000'/1'",
-          ["0/0"],
-          "111122223333444455556666777788889999aaaabbbbccccddddeeeeffff0000"
-        );
-        throw "Expected failure";
-      } catch (e) {
-        expect(e).has.property('statusCode', 0x6985); // REJECT
-        expect(e).has.property('statusText', 'INCORRECT_DATA');
-      } finally {
-        this.speculos.button("RrRLrlRLrlRLrlRrRLrl");
-      }
-    });
+    //   try {
+    //     await checkSignHash(
+    //       this,
+    //       "44'/9000'/1'",
+    //       ["0/0"],
+    //       "111122223333444455556666777788889999aaaabbbbccccddddeeeeffff0000"
+    //     );
+    //     throw "Expected failure";
+    //   } catch (e) {
+    //     expect(e).has.property('statusCode', 0x6985); // REJECT
+    //     expect(e).has.property('statusText', 'INCORRECT_DATA');
+    //   } finally {
+    //     this.speculos.button("RrRLrlRLrlRLrlRrRLrl");
+    //   }
+    // });
 
     it('can sign a transaction based on the serialization reference in verbose mode', async function () {
       const pathPrefix = "44'/9000'/1'";

--- a/tests/basic-tests.js
+++ b/tests/basic-tests.js
@@ -103,24 +103,24 @@ describe("Basic Tests", () => {
       }
     });
 
-    it('rejects signing hash when disallowed in settings', async function () {
-      this.speculos.button("RrRLrlRLrlRrRLrl");
+    // it('rejects signing hash when disallowed in settings', async function () {
+    //   this.speculos.button("RrRLrlRLrlRrRLrl");
 
-      try {
-        await checkSignHash(
-          this,
-          "44'/9000'/1'",
-          ["0/0"],
-          "111122223333444455556666777788889999aaaabbbbccccddddeeeeffff0000"
-        );
-        throw "Expected failure";
-      } catch (e) {
-        expect(e).has.property('statusCode', 0x6985); // REJECT
-        expect(e).has.property('statusText', 'CONDITIONS_OF_USE_NOT_SATISFIED');
-      } finally {
-        this.speculos.button("RrRLrlRLrlRLrlRrRLrl");
-      }
-    });
+    //   try {
+    //     await checkSignHash(
+    //       this,
+    //       "44'/9000'/1'",
+    //       ["0/0"],
+    //       "111122223333444455556666777788889999aaaabbbbccccddddeeeeffff0000"
+    //     );
+    //     throw "Expected failure";
+    //   } catch (e) {
+    //     expect(e).has.property('statusCode', 0x6985); // REJECT
+    //     expect(e).has.property('statusText', 'CONDITIONS_OF_USE_NOT_SATISFIED');
+    //   } finally {
+    //     this.speculos.button("RrRLrlRLrlRLrlRrRLrl");
+    //   }
+    // });
 
     it('can sign a transaction based on the serialization reference in verbose mode', async function () {
       const pathPrefix = "44'/9000'/1'";

--- a/tests/basic-tests.js
+++ b/tests/basic-tests.js
@@ -103,24 +103,24 @@ describe("Basic Tests", () => {
       }
     });
 
-    // it('rejects signing hash when disallowed in settings', async function () {
-    //   this.speculos.button("RrRLrlRLrlRrRLrl");
+    it('rejects signing hash when disallowed in settings', async function () {
+      this.speculos.button("RrRLrlRLrlRrRLrl");
 
-    //   try {
-    //     await checkSignHash(
-    //       this,
-    //       "44'/9000'/1'",
-    //       ["0/0"],
-    //       "111122223333444455556666777788889999aaaabbbbccccddddeeeeffff0000"
-    //     );
-    //     throw "Expected failure";
-    //   } catch (e) {
-    //     expect(e).has.property('statusCode', 0x6985); // REJECT
-    //     expect(e).has.property('statusText', 'INCORRECT_DATA');
-    //   } finally {
-    //     this.speculos.button("RrRLrlRLrlRLrlRrRLrl");
-    //   }
-    // });
+      try {
+        await checkSignHash(
+          this,
+          "44'/9000'/1'",
+          ["0/0"],
+          "111122223333444455556666777788889999aaaabbbbccccddddeeeeffff0000"
+        );
+        throw "Expected failure";
+      } catch (e) {
+        expect(e).has.property('statusCode', 0x6985); // REJECT
+        expect(e).has.property('statusText', 'CONDITIONS_OF_USE_NOT_SATISFIED');
+      } finally {
+        this.speculos.button("RrRLrlRLrlRLrlRrRLrl");
+      }
+    });
 
     it('can sign a transaction based on the serialization reference in verbose mode', async function () {
       const pathPrefix = "44'/9000'/1'";

--- a/tests/hooks.js
+++ b/tests/hooks.js
@@ -167,7 +167,7 @@ async function syncWithLedger(speculos, source, interactionFunc) {
     screen = await source.next();
   }
   // Sink some extra homescreens to make us a bit more durable to failing tests.
-  while(await source.peek().header == "Avalanche" || await source.peek().body == "Quit") {
+  while(await source.peek().header == "Avalanche" || await source.peek().header == "Configuration" || await source.peek().body == "Quit") {
     await source.next();
   }
   // And continue on to interactionFunc

--- a/tests/hooks.js
+++ b/tests/hooks.js
@@ -129,7 +129,7 @@ async function automationStart(speculos, interactionFunc) {
   let subscript = speculos.automationEvents.subscribe({
     next: evt => {
       // Wrap up two-line prompts into one:
-      if(evt.y == 3) {
+      if(evt.y == 3 && evt.text != 'Configuration') { // Configuration header is just one line
         header = evt.text;
         return; // The top line comes out first, so now wait for the next draw.
       } else {


### PR DESCRIPTION
This rejects all sign hash APDUs if set to disabled. The default,
allow with warnings, accepts with some additional prompts.