### PR TITLE
Add display overflow/underflow check on timestamps

### DIFF
--- a/src/to_string.c
+++ b/src/to_string.c
@@ -80,6 +80,7 @@ static inline size_t convert_number_fixed(char dest[MAX_INT_DIGITS], uint64_t nu
         *ptr = '0' + number % 10;
         number /= 10;
     }
+    if (number != 0) THROW(EXC_PARSE_ERROR);
     return padding;
 }
 
@@ -247,6 +248,8 @@ size_t time_to_string(char *const dest, size_t const buff_size, uint64_t const *
         months -= 12;
         years++;
     }
+
+    if (years < 20) THROW(EXC_PARSE_ERROR);
 
     size_t ix = 0;
 


### PR DESCRIPTION
Not sure this is strictly necessary, as the date ranges excluded (on or before `2019-12-31 23:59:59`,  or after `9999-12-31 23:59:59`) should pretty reliably be rejected on-chain,  but this still closes out a possibility for this app to display something misleading,  and it still seems better not give anybody this small (and unnecessary) opening that somebody might be able to string together with other vulnerabilities.