### PR TITLE
Put Delegation Fee in percent

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -756,7 +756,7 @@ enum parse_rv parse_AddValidatorTransaction(struct AddValidatorTransactionState
             }
             CALL_SUBPARSER(uint32State, uint32_t);
             state->state++;
-            if(ADD_PROMPT("Delegation Fee", &state->uint32State.val, sizeof(uint32_t), number_to_string_indirect32)) break;
+            if(ADD_PROMPT("Delegation Fee", &state->uint32State.val, sizeof(uint32_t), delegation_fee_to_string)) break;
                 }
         case 4:
              // This is bc we call the parser recursively, and, at the end, it gets called with

--- a/src/to_string.c
+++ b/src/to_string.c
@@ -100,6 +100,47 @@ void number_to_string_indirect32(char *const dest, size_t const buff_size, uint3
     number_to_string(dest, *number);
 }
 
+#define DELEGATION_FEE_DIGITS 4
+#define DELEGATION_FEE_SCALE 10000
+
+void delegation_fee_to_string(char *const dest, size_t const buff_size, uint32_t const *const delegation_fee) {
+    check_null(dest);
+    check_null(delegation_fee);
+
+    if (buff_size < 13) // 429496.7295%
+      THROW(EXC_WRONG_LENGTH);
+
+    uint32_t whole_percent = *delegation_fee / DELEGATION_FEE_SCALE;
+    uint32_t fractional_percent = *delegation_fee % DELEGATION_FEE_SCALE;
+    size_t off = number_to_string(dest, whole_percent);
+    if (fractional_percent == 0) {
+        dest[off++] = '%';
+        dest[off++] = '\0';
+        return;
+    }
+    dest[off++] = '.';
+
+    char tmp[MAX_INT_DIGITS];
+    convert_number(tmp, fractional_percent, true);
+
+    // Eliminate trailing 0s
+    char *start = tmp + MAX_INT_DIGITS - DELEGATION_FEE_DIGITS;
+    char *end;
+    for (end = tmp + MAX_INT_DIGITS - 1; end >= start; end--) {
+        if (*end != '0') {
+            end++;
+            break;
+        }
+    }
+
+    size_t length = end - start;
+    memcpy(dest + off, start, length);
+    off += length;
+
+    dest[off++] = '%';
+    dest[off++] = '\0';
+}
+
 size_t number_to_string(char *const dest, uint64_t number) {
     check_null(dest);
     char tmp[MAX_INT_DIGITS];

--- a/src/to_string.h
+++ b/src/to_string.h
@@ -21,6 +21,8 @@ void nano_avax_to_string_indirect64(char *const dest, size_t const buff_size, ui
 void number_to_string_indirect64(char *const dest, size_t const buff_size, uint64_t const *const number);
 void number_to_string_indirect32(char *const dest, size_t const buff_size, uint32_t const *const number);
 
+void delegation_fee_to_string(char *const dest, size_t const buff_size, uint32_t const *const delegation_fee);
+
 // `src` may be unrelocated pointer to rodata.
 void copy_string(char *const dest, size_t const buff_size, char const *const src);
 

--- a/tests/p-chain-tests.js
+++ b/tests/p-chain-tests.js
@@ -222,7 +222,7 @@ describe('Staking tests', async function () {
       [{header: 'Weight', body: '54321' }],
       [{header: 'Stake',body: '2000 to local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u'}],
       [{header: 'Rewards To', body: 'local1mg47uqd7stkvqrp57ds7m28txra45u2uzkta8n' }],
-      [{header: 'Delegation Fee', body: '100' }],
+      [{header: 'Delegation Fee', body: '0.01%' }],
       [{header: 'Fee',body: '0.001'}],
       [{header: 'Finalize',body: 'Transaction'}],
     ]);


### PR DESCRIPTION
Delegation fee is listed in 1/10000th of a percent. We just need to
divide it by 10000 to get the fraction and modulo by 10000 to get the
whole percent. Set a 13 byte minimum so we can cover the max uint32
percent (429496.7295%).