### PR TITLE
In C-Chain transfers, display "x AVAX" rather than "y nAVAX" for amounts >= 0.001 Avax

### DIFF
--- a/src/evm_parse.c
+++ b/src/evm_parse.c
@@ -84,7 +84,7 @@ static void output_evm_fee_to_string(char *const out, size_t const out_size, out
   wei_to_gwei_string(out, out_size, in->fee);
 }
 static void output_evm_fund_to_string(char *const out, size_t const out_size, output_prompt_t const *const in) {
-  wei_to_navax_string_256(out, out_size, &in->amount_big);
+  wei_to_avax_or_navax_string_256(out, out_size, &in->amount_big);
 }
 static void output_evm_address_to_string(char *const out, size_t const out_size, output_prompt_t const *const in) {
   output_hex_to_string(out, out_size, &in->address.val, ETHEREUM_ADDRESS_SIZE);
@@ -94,7 +94,7 @@ static void output_evm_bytes32_to_string(char *const out, size_t const out_size,
 }
 
 static void output_evm_prompt_to_string(char *const out, size_t const out_size, output_prompt_t const *const in) {
-    size_t ix = wei_to_navax_string_256(out, out_size, &in->amount_big);
+    size_t ix = wei_to_avax_or_navax_string_256(out, out_size, &in->amount_big);
 
     static char const to[] = " to ";
     if (ix + sizeof(to) > out_size) THROW_(EXC_MEMORY_ERROR, "Can't fit ' to ' into prompt value string");

--- a/src/to_string.h
+++ b/src/to_string.h
@@ -13,7 +13,7 @@ size_t nano_avax_to_string(char *const dest, size_t const buff_size, uint64_t co
 size_t wei_to_gwei_string(char *const dest, size_t const buff_size, uint64_t const wei);
 size_t wei_to_gwei_string_256(char *const dest, size_t const buff_size, uint256_t const wei);
 size_t wei_to_navax_string(char *const dest, size_t const buff_size, uint64_t const wei);
-size_t wei_to_navax_string_256(char *const dest, size_t const buff_size, uint256_t const *const wei);
+size_t wei_to_avax_or_navax_string_256(char *const dest, size_t const buff_size, uint256_t const *const wei);
 
 void bip32_path_to_string(char *const out, size_t const out_size, bip32_path_t const *const path);
 size_t pkh_to_string(char *const out, size_t const out_size, char const *const hrp, size_t const hrp_size,

--- a/tests/eth-tests.js
+++ b/tests/eth-tests.js
@@ -172,7 +172,7 @@ describe("Eth app compatibility tests", async function () {
   it('can sign a transaction via the ethereum ledgerjs module', async function() {
       await testSigning(this, 43114,
                         transferPrompts('0x28ee52a8f3d6e5d15f8b131996950d7f296c7952',
-                                        '12340000 nAVAX',
+                                        '0.01234 AVAX',
                                         '9870000 GWEI'
                                        ),
                         'ed01856d6e2edc008252089428ee52a8f3d6e5d15f8b131996950d7f296c7952872bd72a248740008082a86a8080'
@@ -182,7 +182,7 @@ describe("Eth app compatibility tests", async function () {
   it('can sign a larger transaction via the ethereum ledgerjs module', async function() {
       await testSigning(this, 43114,
                         transferPrompts('0x28ee52a8f3d6e5d15f8b131996950d7f296c7952',
-                                        '238547462614852887054687704548455.429902335 nAVAX',
+                                        '238547462614852887054687.704548455429902335 AVAX',
                                         '9870000 GWEI'),
                         'f83801856d6e2edc008252089428ee52a8f3d6e5d15f8b131996950d7f296c79529202bd072a24087400000f0fff0f0fff0f0fff8082a86a8080'
                        );
@@ -274,7 +274,7 @@ describe("Eth app compatibility tests", async function () {
 
     await testSigning(this, 43114,
                       transferPrompts('0x28ee52a8f3d6e5d15f8b131996950d7f296c7952',
-                                      '12340000 nAVAX',
+                                      '0.01234 AVAX',
                                       '441000 GWEI'),
                       'ed018504e3b292008252089428ee52a8f3d6e5d15f8b131996950d7f296c7952872bd72a248740008082a86a8080'
                      );


### PR DESCRIPTION
## Summary
Currently, C-chain transfers always display in units of `nAVAX`, even for very large transfers. This PR proposes to change the display behavior to display `AVAX` when the transfer amount is >= 0.001 AVAX. 

### Testing
Automated test suite. See also: some expected test outputs were updated too.