### PR TITLE
Support EIP1559-style transactions.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -94,7 +94,7 @@ let
           pkgs.gdb
           pkgs.jq
           pkgs.libusb
-          pkgs.nodejs
+          pkgs.nodejs-12_x
           pkgs.openssl
           pkgs.pkg-config
           pkgs.xxd

--- a/src/apdu_evm_sign.c
+++ b/src/apdu_evm_sign.c
@@ -121,7 +121,7 @@ static void empty_prompt_queue(void) {
 
 static size_t next_parse(bool const is_reentry) {
     PRINTF("Next parse\n");
-    enum parse_rv const rv = parse_rlp_txn(&G.state, &G.meta_state);
+    enum parse_rv const rv = parse_evm_txn(&G.state, &G.meta_state);
     empty_prompt_queue();
 
     if (rv == PARSE_RV_DONE || rv == PARSE_RV_NEED_MORE) {
@@ -165,7 +165,7 @@ size_t handle_apdu_sign_evm_transaction(void) {
           ix += read_bip32_path(&G.bip32_path, &in[ix], in_size - ix);
           check_bip32(&G.bip32_path, false);
           if (G.bip32_path.length < 3) THROW_(EXC_SECURITY, "Signing path not long enough");
-          init_rlp_list(&G.state);
+          init_evm_txn(&G.state);
           cx_keccak_init(&G.tx_hash_state, 256);
       }
       case 0x80: {

--- a/src/apdu_evm_sign.c
+++ b/src/apdu_evm_sign.c
@@ -22,8 +22,15 @@ bool evm_sign_ok() {
     }));
 
     memcpy(out+1, buf, 64);
-    // Ethereum doesn't handle the 4-address case and the protocol only allows one byte; signature will need repair after hw-app-eth has it.
-    out[0] = (buf[64]&0x01) + (G.meta_state.chainIdLowByte<<1) + 35;
+
+    if (G.meta_state.chainIdLowByte == 0) {
+        // we are signing a non-Legacy transaction
+        out[0] = (buf[64]&0x01);
+    } else {
+        // Ethereum doesn't handle the 4-address case and the protocol only allows one byte; signature will need repair after hw-app-eth has it.
+        out[0] = (buf[64]&0x01) + (G.meta_state.chainIdLowByte<<1) + 35;
+    }
+
 
     memset(&G, 0, sizeof(G));
     delayed_send(finalize_successful_send(tx));

--- a/src/evm_parse.c
+++ b/src/evm_parse.c
@@ -189,6 +189,8 @@ uint256_t enforceParsedScalarFits256Bits(struct EVM_RLP_item_state *const state)
   return value;
 }
 
+IMPL_FIXED(uint8_t)
+
 enum parse_rv parse_evm_txn(struct EVM_txn_state *const state, evm_parser_meta_state_t *const meta) {
     enum parse_rv sub_rv;
     switch (state->state) {
@@ -213,7 +215,7 @@ enum parse_rv parse_evm_txn(struct EVM_txn_state *const state, evm_parser_meta_s
           }
           case LEGACY: {
             // we consumed a byte that the Legacy parser was expecting, so decrement before legacy parser begins
-            if (input.consumed < 1) {
+            if (meta->input.consumed < 1) {
               REJECT("a byte was consumed but this was not reflected in the \"input consumed bytes\" counter") // should be impossible
             }
             meta->input.consumed--; 

--- a/src/evm_parse.c
+++ b/src/evm_parse.c
@@ -162,7 +162,7 @@ enum eth_eip1559_txn_items {
   EVM_EIP1559_TXN_VALUE,
   EVM_EIP1559_TXN_DATA,
   EVM_EIP1559_TXN_ACCESS_LIST
-}
+};
 
 void init_assetCall_data(struct EVM_assetCall_state *const state, uint64_t length);
 enum parse_rv parse_assetCall_data(struct EVM_assetCall_state *const state, parser_input_meta_state_t *const input, evm_parser_meta_state_t *const meta);
@@ -540,7 +540,7 @@ enum parse_rv parse_eip1559_rlp_txn(struct EVM_RLP_txn_state *const state, evm_p
             // TODO: We don't currently support the C-chain gas limit of 100 million,
             // which would have a fee larger than what fits in a word
             // possible future improvement: using nanosdk to actually do the overflow-checked gas arithmetic
-            if(max(maxFeePerGasLength, baseFeePerGasLength) + gasLimit > 8)
+            if((maxFeePerGasLength > baseFeePerGasLength ? maxFeePerGasLength : baseFeePerGasLength) + gasLimit + 1 > 8)
               REJECT("Fee too large");
 
 

--- a/src/evm_parse.c
+++ b/src/evm_parse.c
@@ -540,7 +540,7 @@ enum parse_rv parse_eip1559_rlp_txn(struct EVM_RLP_txn_state *const state, evm_p
             // TODO: We don't currently support the C-chain gas limit of 100 million,
             // which would have a fee larger than what fits in a word
             // possible future improvement: using nanosdk to actually do the overflow-checked gas arithmetic
-            if((maxFeePerGasLength > baseFeePerGasLength ? maxFeePerGasLength : baseFeePerGasLength) + gasLimit + 1 > 8)
+            if((maxFeePerGasLength > baseFeePerGasLength ? maxFeePerGasLength : baseFeePerGasLength) + gasLimitLength + 1 > 8)
               REJECT("Fee too large");
 
 

--- a/src/evm_parse.c
+++ b/src/evm_parse.c
@@ -140,17 +140,29 @@ enum parse_rv parse_rlp_item(struct EVM_RLP_txn_state *const state, evm_parser_m
 enum parse_rv parse_rlp_item_to_buffer(struct EVM_RLP_txn_state *const state, evm_parser_meta_state_t *const meta);
 enum parse_rv parse_rlp_item_data(struct EVM_RLP_txn_state *const state, evm_parser_meta_state_t *const meta);
 
-enum eth_txn_items {
-  EVM_TXN_NONCE,
-  EVM_TXN_GASPRICE,
-  EVM_TXN_STARTGAS,
-  EVM_TXN_TO,
-  EVM_TXN_VALUE,
-  EVM_TXN_DATA,
-  EVM_TXN_CHAINID,
-  EVM_TXN_SIG_R,
-  EVM_TXN_SIG_S
+enum eth_legacy_txn_items {
+  EVM_LEGACY_TXN_NONCE,
+  EVM_LEGACY_TXN_GASPRICE,
+  EVM_LEGACY_TXN_STARTGAS,
+  EVM_LEGACY_TXN_TO,
+  EVM_LEGACY_TXN_VALUE,
+  EVM_LEGACY_TXN_DATA,
+  EVM_LEGACY_TXN_CHAINID,
+  EVM_LEGACY_TXN_SIG_R,
+  EVM_LEGACY_TXN_SIG_S
 };
+
+enum eth_eip1559_txn_items {
+  EVM_EIP1559_TXN_CHAINID,
+  EVM_EIP1559_TXN_NONCE,
+  EVM_EIP1559_TXN_MAX_PRIORITY_FEE_PER_GAS,
+  EVM_EIP1559_TXN_MAX_FEE_PER_GAS,
+  EVM_EIP1559_TXN_GAS_LIMIT,
+  EVM_EIP1559_TXN_TO,
+  EVM_EIP1559_TXN_VALUE,
+  EVM_EIP1559_TXN_DATA,
+  EVM_EIP1559_TXN_ACCESS_LIST
+}
 
 void init_assetCall_data(struct EVM_assetCall_state *const state, uint64_t length);
 enum parse_rv parse_assetCall_data(struct EVM_assetCall_state *const state, parser_input_meta_state_t *const input, evm_parser_meta_state_t *const meta);
@@ -235,6 +247,18 @@ void init_evm_txn(struct EVM_txn_state *const state) {
     state->state = 0; 
     init_uint8_t(&state->transaction_envelope_type);
 }
+#define PARSE_ITEM(ITEM, save) \
+            case ITEM: {\
+                itemStartIdx = meta->input.consumed; \
+                PRINTF("Entering " #ITEM "\n");                          \
+                sub_rv = parse_rlp_item ## save(state, meta); \
+                PRINTF("Exiting " #ITEM "\n");                          \
+                state->remaining -= meta->input.consumed - itemStartIdx; \
+            } (void)0
+#define FINISH_ITEM_CHUNK() \
+            if(sub_rv != PARSE_RV_DONE) return sub_rv;                  \
+            state->item_index++;                                        \
+            init_rlp_item(&state->rlpItem_state);
 
 enum parse_rv parse_legacy_rlp_txn(struct EVM_RLP_txn_state *const state, evm_parser_meta_state_t *const meta) {
     enum parse_rv sub_rv;
@@ -265,39 +289,27 @@ enum parse_rv parse_legacy_rlp_txn(struct EVM_RLP_txn_state *const state, evm_pa
       case 2: { // Now parse items.
           uint8_t itemStartIdx;
           switch(state->item_index) {
-#define PARSE_ITEM(ITEM, save) \
-            case ITEM: {\
-                itemStartIdx = meta->input.consumed; \
-                PRINTF("Entering " #ITEM "\n");                          \
-                sub_rv = parse_rlp_item ## save(state, meta); \
-                PRINTF("Exiting " #ITEM "\n");                          \
-                state->remaining -= meta->input.consumed - itemStartIdx; \
-            } (void)0
-#define FINISH_ITEM_CHUNK() \
-            if(sub_rv != PARSE_RV_DONE) return sub_rv;                  \
-            state->item_index++;                                        \
-            init_rlp_item(&state->rlpItem_state);
 
-            PARSE_ITEM(EVM_TXN_NONCE, );
+            PARSE_ITEM(EVM_LEGACY_TXN_NONCE, );
             FINISH_ITEM_CHUNK();
 
-            PARSE_ITEM(EVM_TXN_GASPRICE, _to_buffer);
+            PARSE_ITEM(EVM_LEGACY_TXN_GASPRICE, _to_buffer);
             uint64_t gasPrice = enforceParsedScalarFits64Bits(&state->rlpItem_state);
             size_t gasPriceLength = state->rlpItem_state.length; // TODO is this length handling dead code? now that enforceParsed handles length
-            state->gasPrice = gasPrice;
+            state->priorityFeePerGas = gasPrice;
             FINISH_ITEM_CHUNK();
 
-            PARSE_ITEM(EVM_TXN_STARTGAS, _to_buffer);
+            PARSE_ITEM(EVM_LEGACY_TXN_STARTGAS, _to_buffer);
             uint64_t startGas = enforceParsedScalarFits64Bits(&state->rlpItem_state);
             size_t startGasLength = state->rlpItem_state.length; // TODO is this length handling dead code? now that enforceParsed handles length
-            state->startGas = startGas;
+            state->gasLimit = startGas;
             // TODO: We don't currently support the C-chain gas limit of 100 million,
             // which would have a fee larger than what fits in a word
             if(gasPriceLength + startGasLength > 8)
               REJECT("Fee too large");
             FINISH_ITEM_CHUNK();
 
-            PARSE_ITEM(EVM_TXN_TO, _to_buffer);
+            PARSE_ITEM(EVM_LEGACY_TXN_TO, _to_buffer);
 
             switch (state->rlpItem_state.length) {
             case 0:
@@ -327,13 +339,13 @@ enum parse_rv parse_legacy_rlp_txn(struct EVM_RLP_txn_state *const state, evm_pa
               set_next_batch_size(&meta->prompt, 2);
               if(({
                   ADD_PROMPT("Contract", label, sizeof(label), strcpy_prompt);
-                  SET_PROMPT_VALUE(entry->data.output_prompt.start_gas = state->startGas);
+                  SET_PROMPT_VALUE(entry->data.output_prompt.start_gas = state->gasLimit);
                   ADD_ACCUM_PROMPT("Gas Limit", output_evm_gas_limit_to_string);
                 }))
                 return PARSE_RV_PROMPT;
             }
 
-            PARSE_ITEM(EVM_TXN_VALUE, _to_buffer);
+            PARSE_ITEM(EVM_LEGACY_TXN_VALUE, _to_buffer);
 
             state->value = enforceParsedScalarFits256Bits(&state->rlpItem_state);
             SET_PROMPT_VALUE(entry->data.output_prompt.amount_big = state->value);
@@ -352,7 +364,7 @@ enum parse_rv parse_legacy_rlp_txn(struct EVM_RLP_txn_state *const state, evm_pa
                 if(ADD_ACCUM_PROMPT("Funding Contract", output_evm_fund_to_string)) return PARSE_RV_PROMPT;
             }
 
-            PARSE_ITEM(EVM_TXN_DATA, _data);
+            PARSE_ITEM(EVM_LEGACY_TXN_DATA, _data);
 
             // If data field can't possibly fit in the transaction, the rlp is malformed
             if(state->rlpItem_state.len_len > state->remaining)
@@ -414,7 +426,7 @@ enum parse_rv parse_legacy_rlp_txn(struct EVM_RLP_txn_state *const state, evm_pa
               if(ADD_ACCUM_PROMPT("Data", output_evm_calldata_preview_to_string))
                 return PARSE_RV_PROMPT;
             }
-            PARSE_ITEM(EVM_TXN_CHAINID, _to_buffer);
+            PARSE_ITEM(EVM_LEGACY_TXN_CHAINID, _to_buffer);
 
             if(state->rlpItem_state.length != 2
                || state->rlpItem_state.buffer[0] != 0xa8
@@ -427,7 +439,7 @@ enum parse_rv parse_legacy_rlp_txn(struct EVM_RLP_txn_state *const state, evm_pa
 
             FINISH_ITEM_CHUNK();
 
-            SET_PROMPT_VALUE(entry->data.output_prompt.fee = state->gasPrice * state->startGas);
+            SET_PROMPT_VALUE(entry->data.output_prompt.fee = state->priorityFeePerGas * state->gasLimit);
             if(state->hasData) {
               if(ADD_ACCUM_PROMPT("Maximum Fee", output_evm_fee_to_string))
                 return PARSE_RV_PROMPT;
@@ -437,12 +449,12 @@ enum parse_rv parse_legacy_rlp_txn(struct EVM_RLP_txn_state *const state, evm_pa
                 return PARSE_RV_PROMPT;
             }
 
-            PARSE_ITEM(EVM_TXN_SIG_R, _to_buffer);
+            PARSE_ITEM(EVM_LEGACY_TXN_SIG_R, _to_buffer);
 
             if(state->rlpItem_state.length != 0) REJECT("R value must be 0 for signing with EIP-155.");
 
             FINISH_ITEM_CHUNK();
-            PARSE_ITEM(EVM_TXN_SIG_S, _to_buffer);
+            PARSE_ITEM(EVM_LEGACY_TXN_SIG_S, _to_buffer);
 
             if(state->rlpItem_state.length != 0) REJECT("S value must be 0 for signing with EIP-155.");
             FINISH_ITEM_CHUNK();
@@ -464,7 +476,220 @@ enum parse_rv parse_legacy_rlp_txn(struct EVM_RLP_txn_state *const state, evm_pa
 }
 
 enum parse_rv parse_eip1559_rlp_txn(struct EVM_RLP_txn_state *const state, evm_parser_meta_state_t *const meta) {
+    enum parse_rv sub_rv;
+    switch(state->state) {
+      case 0: {
+          if(meta->input.consumed >= meta->input.length) return PARSE_RV_NEED_MORE;
+          uint8_t first = meta->input.src[meta->input.consumed++];
+          if(first < 0xc0) REJECT("Transaction not an RLP list");
+          if(first < 0xf8) {
+              state->remaining = first - 0xc0;
+              state->state=2;
+          } else {
+              state->len_len = first - 0xf7;
+              state->state=1;
+          }
+      }
+      case 1:
+        if(state->state==1) {
+            // Max length we could get for this value is 8 bytes so uint64_state is appropriate.
+            sub_rv = parseFixed(((struct FixedState*)&state->uint64_state), &meta->input, state->len_len);
+            if(sub_rv != PARSE_RV_DONE) return sub_rv;
+            for(size_t i = 0; i < state->len_len; i++) {
+                ((uint8_t*)(&state->remaining))[i] = state->uint64_state.buf[state->len_len-i-1];
+            }
+        }
+        init_rlp_item(&state->rlpItem_state);
+        state->state = 2;
+      case 2: { // Now parse items.
+          uint8_t itemStartIdx;
+          switch(state->item_index) {
+            PARSE_ITEM(EVM_EIP1559_TXN_CHAINID, _to_buffer);
 
+            if(state->rlpItem_state.length != 2
+               || state->rlpItem_state.buffer[0] != 0xa8
+               || (state->rlpItem_state.buffer[1] != 0x68
+                   && state->rlpItem_state.buffer[1] != 0x69
+                   && state->rlpItem_state.buffer[1] != 0x6a))
+                REJECT("Chain ID incorrect for the Avalanche C chain");
+            meta->chainIdLowByte = 0; // explicitly clear chain ID low byte for EIP1559 transactions - only legacy transactions needed to include it
+
+            FINISH_ITEM_CHUNK();
+
+            PARSE_ITEM(EVM_EIP1559_TXN_NONCE, );
+            FINISH_ITEM_CHUNK();
+
+            PARSE_ITEM(EVM_EIP1559_TXN_MAX_PRIORITY_FEE_PER_GAS, _to_buffer);
+            uint64_t maxFeePerGas = enforceParsedScalarFits64Bits(&state->rlpItem_state);
+            size_t maxFeePerGasLength = state->rlpItem_state.length;
+            state->priorityFeePerGas = maxFeePerGas;
+            FINISH_ITEM_CHUNK();
+
+            PARSE_ITEM(EVM_EIP1559_TXN_MAX_FEE_PER_GAS, _to_buffer);
+            uint64_t baseFeePerGas = enforceParsedScalarFits64Bits(&state->rlpItem_state);
+            size_t baseFeePerGasLength = state->rlpItem_state.length;
+            state->baseFeePerGas = baseFeePerGas;
+            FINISH_ITEM_CHUNK();
+
+            PARSE_ITEM(EVM_EIP1559_TXN_GAS_LIMIT, _to_buffer);
+            uint64_t gasLimit = enforceParsedScalarFits64Bits(&state->rlpItem_state);
+            size_t gasLimitLength = state->rlpItem_state.length;
+            state->gasLimit = gasLimit;
+            FINISH_ITEM_CHUNK();
+
+            // TODO: We don't currently support the C-chain gas limit of 100 million,
+            // which would have a fee larger than what fits in a word
+            // possible future improvement: using nanosdk to actually do the overflow-checked gas arithmetic
+            if(max(maxFeePerGasLength, baseFeePerGasLength) + gasLimit > 8)
+              REJECT("Fee too large");
+
+
+            PARSE_ITEM(EVM_EIP1559_TXN_TO, _to_buffer);
+
+            switch (state->rlpItem_state.length) {
+            case 0:
+              state->hasTo = false;
+              break;
+            case ETHEREUM_ADDRESS_SIZE:
+              state->hasTo = true;
+              break;
+            default:
+              REJECT("When present, destination address must have exactly %u bytes", ETHEREUM_ADDRESS_SIZE);
+            }
+
+            if(state->hasTo) {
+              for(size_t i = 0; i < NUM_ELEMENTS(precompiled); i++) {
+                if(!memcmp(precompiled[i].to, state->rlpItem_state.buffer, ETHEREUM_ADDRESS_SIZE)) {
+                  meta->known_destination = &precompiled[i];
+                  break;
+                }
+              }
+              if(!meta->known_destination)
+                SET_PROMPT_VALUE(memcpy(entry->data.output_prompt.address.val, state->rlpItem_state.buffer, ETHEREUM_ADDRESS_SIZE));
+              FINISH_ITEM_CHUNK();
+            }
+            else {
+              FINISH_ITEM_CHUNK();
+              static char const label []="Creation";
+              set_next_batch_size(&meta->prompt, 2);
+              if(({
+                  ADD_PROMPT("Contract", label, sizeof(label), strcpy_prompt);
+                  SET_PROMPT_VALUE(entry->data.output_prompt.start_gas = state->gasLimit);
+                  ADD_ACCUM_PROMPT("Gas Limit", output_evm_gas_limit_to_string);
+                }))
+                return PARSE_RV_PROMPT;
+            }
+
+            PARSE_ITEM(EVM_EIP1559_TXN_VALUE, _to_buffer);
+
+            state->value = enforceParsedScalarFits256Bits(&state->rlpItem_state);
+            SET_PROMPT_VALUE(entry->data.output_prompt.amount_big = state->value);
+
+            FINISH_ITEM_CHUNK();
+
+            if(state->hasTo) {
+              // As of now, there is no known reason to send AVAX to any precompiled contract we support
+              // Given that, we take the less risky action with the intent of protecting from unintended transfers
+              if(meta->known_destination) {
+                if (!zero256(&state->value))
+                  REJECT("Transactions sent to precompiled contracts must have an amount of 0 WEI");
+              }
+            } else {
+              if(!zero256(&state->value))
+                if(ADD_ACCUM_PROMPT("Funding Contract", output_evm_fund_to_string)) return PARSE_RV_PROMPT;
+            }
+
+            PARSE_ITEM(EVM_EIP1559_TXN_DATA, _data);
+
+            // If data field can't possibly fit in the transaction, the rlp is malformed
+            if(state->rlpItem_state.len_len > state->remaining)
+              REJECT("Malformed data length. Expected length of length %u", state->rlpItem_state.len_len);
+
+            // If we exhaust the apdu while parsing the length, there's nothing yet to hand to the subparser
+            if(state->rlpItem_state.state < 2)
+              return sub_rv;
+
+            if(state->hasTo) {
+              if(meta->known_destination) {
+                if(state->rlpItem_state.do_init && meta->known_destination->init_data)
+                  ((known_destination_init)PIC(meta->known_destination->init_data))(&(state->rlpItem_state.endpoint_state), state->rlpItem_state.length);
+                PRINTF("INIT: %u\n", state->rlpItem_state.do_init);
+                PRINTF("Chunk: [%u] %.*h\n", state->rlpItem_state.chunk.length, state->rlpItem_state.chunk.length, state->rlpItem_state.chunk.src);
+                if(meta->known_destination->handle_data) {
+                  PRINTF("HANDLING DATA\n");
+                  sub_rv = ((known_destination_parser)PIC(meta->known_destination->handle_data))(&(state->rlpItem_state.endpoint_state), &(state->rlpItem_state.chunk), meta);
+                }
+                PRINTF("PARSER CALLED [sub_rv: %u]\n", sub_rv);
+              }
+              else {
+                struct EVM_RLP_item_state *const item_state = &state->rlpItem_state;
+                struct EVM_ABI_state *const abi_state = &item_state->endpoint_state.abi_state;
+                if(item_state->do_init)
+                  init_abi_call_data(abi_state, item_state->length);
+
+                if(abi_state->data_length == 0) {
+                  sub_rv = PARSE_RV_DONE;
+                  state->item_index++;
+                  init_rlp_item(&state->rlpItem_state);
+                  ADD_ACCUM_PROMPT("Transfer", output_evm_prompt_to_string);
+                  return PARSE_RV_PROMPT;
+                }
+                else {
+                  sub_rv = parse_abi_call_data(abi_state,
+                                               &item_state->chunk,
+                                               meta,
+                                               !zero256(&state->value));
+                }
+              }
+            }
+
+            // Can't use the FINISH_ITEM_ macro here because we need to do a prompt in the middle of it.
+            if(sub_rv != PARSE_RV_DONE) return sub_rv;
+            state->item_index++;
+            uint64_t len = state->rlpItem_state.length;
+            if(!state->hasTo) {
+              SET_PROMPT_VALUE(entry->data.output_prompt.calldata_preview.cropped = len > MAX_CALLDATA_PREVIEW);
+              SET_PROMPT_VALUE(entry->data.output_prompt.calldata_preview.count = MIN(len, (uint64_t)MAX_CALLDATA_PREVIEW));
+              SET_PROMPT_VALUE(memcpy(entry->data.output_prompt.calldata_preview.buffer,
+                                      &state->rlpItem_state.buffer,
+                                      entry->data.output_prompt.calldata_preview.count));
+            }
+            state->hasData = len > 0;
+            init_rlp_item(&state->rlpItem_state);
+
+            if(!state->hasTo) {
+              if(ADD_ACCUM_PROMPT("Data", output_evm_calldata_preview_to_string))
+                return PARSE_RV_PROMPT;
+            }
+
+            SET_PROMPT_VALUE(entry->data.output_prompt.fee = ((state->priorityFeePerGas + state->baseFeePerGas) * state->gasLimit));
+            if(state->hasData) {
+              if(ADD_ACCUM_PROMPT("Maximum Fee", output_evm_fee_to_string))
+                return PARSE_RV_PROMPT;
+            }
+            else {
+              if(ADD_ACCUM_PROMPT("Fee", output_evm_fee_to_string))
+                return PARSE_RV_PROMPT;
+            }
+
+            PARSE_ITEM(EVM_EIP1559_TXN_ACCESS_LIST, );
+            // just ignore this access list
+            FINISH_ITEM_CHUNK();
+          }
+
+          if(state->remaining == 0) {
+              state->state = 3;
+              return PARSE_RV_DONE;
+          } else
+              REJECT("Reported total size of transaction did not match sum of pieces");
+      }
+      case 3:
+        sub_rv = PARSE_RV_DONE;
+        return sub_rv;
+      default:
+        REJECT("Transaction parser in supposedly unreachable state");
+    }
+    return sub_rv;
 }
 
 enum parse_rv impl_parse_rlp_item(struct EVM_RLP_item_state *const state, evm_parser_meta_state_t *const meta, size_t max_bytes_to_buffer) {

--- a/src/globals.h
+++ b/src/globals.h
@@ -38,7 +38,7 @@ typedef struct {
     buffer_t final_hash_as_buffer;
     cx_sha3_t tx_hash_state;
     struct {
-        struct EVM_RLP_txn_state state;
+        struct EVM_txn_state state;
         evm_parser_meta_state_t meta_state;
     };
 } apdu_evm_sign_state_t;

--- a/src/globals.h
+++ b/src/globals.h
@@ -38,7 +38,7 @@ typedef struct {
     buffer_t final_hash_as_buffer;
     cx_sha3_t tx_hash_state;
     struct {
-        struct EVM_RLP_list_state state;
+        struct EVM_RLP_txn_state state;
         evm_parser_meta_state_t meta_state;
     };
 } apdu_evm_sign_state_t;

--- a/src/parser.c
+++ b/src/parser.c
@@ -108,6 +108,7 @@ enum parse_rv skipBytes(struct FixedState *const state, parser_input_meta_state_
         return initFixed((struct FixedState *const)state, sizeof(state)); \
     }
 
+IMPL_FIXED(uint8_t);
 IMPL_FIXED_BE(uint16_t);
 IMPL_FIXED_BE(uint32_t);
 IMPL_FIXED_BE(uint64_t);

--- a/src/parser.h
+++ b/src/parser.h
@@ -547,6 +547,12 @@ enum parse_rv parseFixed(struct FixedState *const state, parser_input_meta_state
 
 void init_rlp_list(struct EVM_RLP_txn_state *const state);
 
+void init_evm_txn(struct EVM_txn_state *const state);
+
+enum parse_rv parse_evm_txn(struct EVM_txn_state *const state, evm_parser_meta_state_t *const meta);
+
+enum parse_rv parse_eip1559_rlp_txn(struct EVM_RLP_txn_state *const state, evm_parser_meta_state_t *const meta);
+
 enum parse_rv parse_legacy_rlp_txn(struct EVM_RLP_txn_state *const state, evm_parser_meta_state_t *const meta);
 
 void strcpy_prompt(char *const out, size_t const out_size, char const *const in);

--- a/src/parser.h
+++ b/src/parser.h
@@ -523,8 +523,9 @@ struct EVM_RLP_txn_state {
     uint8_t item_index;
     bool hasTo;
     bool hasData;
-    uint64_t startGas;
-    uint64_t gasPrice;
+    uint64_t gasLimit;
+    uint64_t priorityFeePerGas;
+    uint64_t baseFeePerGas;
     uint256_t value;
     union {
         struct uint64_t_state uint64_state;

--- a/src/parser.h
+++ b/src/parser.h
@@ -59,6 +59,7 @@ struct FixedState {
         }; \
     };
 
+DEFINE_FIXED(uint8_t);
 DEFINE_FIXED_BE(uint16_t);
 DEFINE_FIXED_BE(uint32_t);
 DEFINE_FIXED_BE(uint64_t);
@@ -510,7 +511,12 @@ struct EVM_RLP_item_state {
     };
 };
 
-struct EVM_RLP_list_state {
+enum txn_being_parsed_t {
+  LEGACY,
+  EIP1559
+};
+
+struct EVM_RLP_txn_state {
     int state;
     uint64_t remaining;
     uint8_t len_len;
@@ -526,13 +532,22 @@ struct EVM_RLP_list_state {
     };
 };
 
+struct EVM_txn_state {
+    int state; // what step of parsing we are on
+    enum txn_being_parsed_t type; 
+    union {
+      struct uint8_t_state transaction_envelope_type;
+      struct EVM_RLP_txn_state txn_state;
+    };
+};
+
 void initFixed(struct FixedState *const state, size_t const len);
 
 enum parse_rv parseFixed(struct FixedState *const state, parser_input_meta_state_t *const input, size_t const len);
 
-void init_rlp_list(struct EVM_RLP_list_state *const state);
+void init_rlp_list(struct EVM_RLP_txn_state *const state);
 
-enum parse_rv parse_rlp_txn(struct EVM_RLP_list_state *const state, evm_parser_meta_state_t *const meta);
+enum parse_rv parse_legacy_rlp_txn(struct EVM_RLP_txn_state *const state, evm_parser_meta_state_t *const meta);
 
 void strcpy_prompt(char *const out, size_t const out_size, char const *const in);
 

--- a/tests/eth-tests.js
+++ b/tests/eth-tests.js
@@ -218,7 +218,7 @@ const testData = {
         );
       });
       
-    it.only('can sign an EIP1559 transaction via the ethereum ledgerjs module', async function() {
+    it('can sign an EIP1559 transaction via the ethereum ledgerjs module', async function() {
       
       
   //{ chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, to, value, data,

--- a/tests/package.json
+++ b/tests/package.json
@@ -31,8 +31,8 @@
 		"uglify-js": "^3.6.1"
 	},
 	"dependencies": {
-		"@ethereumjs/common": "2.0.0",
-		"@ethereumjs/tx": "3.0.0",
+		"@ethereumjs/common": "^2.4.0",
+		"@ethereumjs/tx": "^3.2.0",
 		"@ledgerhq/hw-app-eth": "5.39.1",
 		"@ledgerhq/hw-transport-node-hid": "5.22.0",
 		"@ledgerhq/hw-transport-node-speculos": "5.19.1",
@@ -41,6 +41,7 @@
 		"create-hash": "1.2.0",
 		"ethereumjs-util": "^7.0.10",
 		"hw-app-avalanche": "https://github.com/obsidiansystems/hw-app-avalanche.git#eac@verbose-signing-multi",
-		"rlp": "2.2.6"
+		"rlp": "2.2.6",
+		"yargs": "^17.1.0"
 	}
 }

--- a/tests/package.json
+++ b/tests/package.json
@@ -33,7 +33,7 @@
 	"dependencies": {
 		"@ethereumjs/common": "^2.4.0",
 		"@ethereumjs/tx": "^3.2.0",
-		"@ledgerhq/hw-app-eth": "5.39.1",
+		"@ledgerhq/hw-app-eth": "^6.4.1",
 		"@ledgerhq/hw-transport-node-hid": "5.22.0",
 		"@ledgerhq/hw-transport-node-speculos": "5.19.1",
 		"bip32-path": "^0.4.2",

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -445,6 +445,345 @@
     "@ethereumjs/common" "^2.4.0"
     ethereumjs-util "^7.1.0"
 
+"@ethersproject/abi@5.4.0", "@ethersproject/abi@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.4.0.tgz#a6d63bdb3672f738398846d4279fa6b6c9818242"
+  integrity sha512-9gU2H+/yK1j2eVMdzm6xvHSnMxk8waIHQGYCZg5uvAyH0rsAzxkModzBSpbAkAuhKFEovC2S9hM4nPuLym8IZw==
+  dependencies:
+    "@ethersproject/address" "^5.4.0"
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/constants" "^5.4.0"
+    "@ethersproject/hash" "^5.4.0"
+    "@ethersproject/keccak256" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/strings" "^5.4.0"
+
+"@ethersproject/abstract-provider@5.4.1", "@ethersproject/abstract-provider@^5.4.0":
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.4.1.tgz#e404309a29f771bd4d28dbafadcaa184668c2a6e"
+  integrity sha512-3EedfKI3LVpjSKgAxoUaI+gB27frKsxzm+r21w9G60Ugk+3wVLQwhi1LsEJAKNV7WoZc8CIpNrATlL1QFABjtQ==
+  dependencies:
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/networks" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/transactions" "^5.4.0"
+    "@ethersproject/web" "^5.4.0"
+
+"@ethersproject/abstract-signer@5.4.1", "@ethersproject/abstract-signer@^5.4.0":
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.4.1.tgz#e4e9abcf4dd4f1ba0db7dff9746a5f78f355ea81"
+  integrity sha512-SkkFL5HVq1k4/25dM+NWP9MILgohJCgGv5xT5AcRruGz4ILpfHeBtO/y6j+Z3UN/PAjDeb4P7E51Yh8wcGNLGA==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.4.0"
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+
+"@ethersproject/address@5.4.0", "@ethersproject/address@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.4.0.tgz#ba2d00a0f8c4c0854933b963b9a3a9f6eb4a37a3"
+  integrity sha512-SD0VgOEkcACEG/C6xavlU1Hy3m5DGSXW3CUHkaaEHbAPPsgi0coP5oNPsxau8eTlZOk/bpa/hKeCNoK5IzVI2Q==
+  dependencies:
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/keccak256" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/rlp" "^5.4.0"
+
+"@ethersproject/base64@5.4.0", "@ethersproject/base64@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.4.0.tgz#7252bf65295954c9048c7ca5f43e5c86441b2a9a"
+  integrity sha512-CjQw6E17QDSSC5jiM9YpF7N1aSCHmYGMt9bWD8PWv6YPMxjsys2/Q8xLrROKI3IWJ7sFfZ8B3flKDTM5wlWuZQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.4.0"
+
+"@ethersproject/basex@5.4.0", "@ethersproject/basex@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/basex/-/basex-5.4.0.tgz#0a2da0f4e76c504a94f2b21d3161ed9438c7f8a6"
+  integrity sha512-J07+QCVJ7np2bcpxydFVf/CuYo9mZ7T73Pe7KQY4c1lRlrixMeblauMxHXD0MPwFmUHZIILDNViVkykFBZylbg==
+  dependencies:
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+
+"@ethersproject/bignumber@5.4.1", "@ethersproject/bignumber@^5.4.0":
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.4.1.tgz#64399d3b9ae80aa83d483e550ba57ea062c1042d"
+  integrity sha512-fJhdxqoQNuDOk6epfM7yD6J8Pol4NUCy1vkaGAkuujZm0+lNow//MKu1hLhRiYV4BsOHyBv5/lsTjF+7hWwhJg==
+  dependencies:
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    bn.js "^4.11.9"
+
+"@ethersproject/bytes@5.4.0", "@ethersproject/bytes@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.4.0.tgz#56fa32ce3bf67153756dbaefda921d1d4774404e"
+  integrity sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==
+  dependencies:
+    "@ethersproject/logger" "^5.4.0"
+
+"@ethersproject/constants@5.4.0", "@ethersproject/constants@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.4.0.tgz#ee0bdcb30bf1b532d2353c977bf2ef1ee117958a"
+  integrity sha512-tzjn6S7sj9+DIIeKTJLjK9WGN2Tj0P++Z8ONEIlZjyoTkBuODN+0VfhAyYksKi43l1Sx9tX2VlFfzjfmr5Wl3Q==
+  dependencies:
+    "@ethersproject/bignumber" "^5.4.0"
+
+"@ethersproject/contracts@5.4.1":
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.4.1.tgz#3eb4f35b7fe60a962a75804ada2746494df3e470"
+  integrity sha512-m+z2ZgPy4pyR15Je//dUaymRUZq5MtDajF6GwFbGAVmKz/RF+DNIPwF0k5qEcL3wPGVqUjFg2/krlCRVTU4T5w==
+  dependencies:
+    "@ethersproject/abi" "^5.4.0"
+    "@ethersproject/abstract-provider" "^5.4.0"
+    "@ethersproject/abstract-signer" "^5.4.0"
+    "@ethersproject/address" "^5.4.0"
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/constants" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/transactions" "^5.4.0"
+
+"@ethersproject/hash@5.4.0", "@ethersproject/hash@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.4.0.tgz#d18a8e927e828e22860a011f39e429d388344ae0"
+  integrity sha512-xymAM9tmikKgbktOCjW60Z5sdouiIIurkZUr9oW5NOex5uwxrbsYG09kb5bMcNjlVeJD3yPivTNzViIs1GCbqA==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.4.0"
+    "@ethersproject/address" "^5.4.0"
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/keccak256" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/strings" "^5.4.0"
+
+"@ethersproject/hdnode@5.4.0", "@ethersproject/hdnode@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hdnode/-/hdnode-5.4.0.tgz#4bc9999b9a12eb5ce80c5faa83114a57e4107cac"
+  integrity sha512-pKxdS0KAaeVGfZPp1KOiDLB0jba11tG6OP1u11QnYfb7pXn6IZx0xceqWRr6ygke8+Kw74IpOoSi7/DwANhy8Q==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.4.0"
+    "@ethersproject/basex" "^5.4.0"
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/pbkdf2" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/sha2" "^5.4.0"
+    "@ethersproject/signing-key" "^5.4.0"
+    "@ethersproject/strings" "^5.4.0"
+    "@ethersproject/transactions" "^5.4.0"
+    "@ethersproject/wordlists" "^5.4.0"
+
+"@ethersproject/json-wallets@5.4.0", "@ethersproject/json-wallets@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/json-wallets/-/json-wallets-5.4.0.tgz#2583341cfe313fc9856642e8ace3080154145e95"
+  integrity sha512-igWcu3fx4aiczrzEHwG1xJZo9l1cFfQOWzTqwRw/xcvxTk58q4f9M7cjh51EKphMHvrJtcezJ1gf1q1AUOfEQQ==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.4.0"
+    "@ethersproject/address" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/hdnode" "^5.4.0"
+    "@ethersproject/keccak256" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/pbkdf2" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/random" "^5.4.0"
+    "@ethersproject/strings" "^5.4.0"
+    "@ethersproject/transactions" "^5.4.0"
+    aes-js "3.0.0"
+    scrypt-js "3.0.1"
+
+"@ethersproject/keccak256@5.4.0", "@ethersproject/keccak256@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.4.0.tgz#7143b8eea4976080241d2bd92e3b1f1bf7025318"
+  integrity sha512-FBI1plWet+dPUvAzPAeHzRKiPpETQzqSUWR1wXJGHVWi4i8bOSrpC3NwpkPjgeXG7MnugVc1B42VbfnQikyC/A==
+  dependencies:
+    "@ethersproject/bytes" "^5.4.0"
+    js-sha3 "0.5.7"
+
+"@ethersproject/logger@5.4.0", "@ethersproject/logger@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.4.0.tgz#f39adadf62ad610c420bcd156fd41270e91b3ca9"
+  integrity sha512-xYdWGGQ9P2cxBayt64d8LC8aPFJk6yWCawQi/4eJ4+oJdMMjEBMrIcIMZ9AxhwpPVmnBPrsB10PcXGmGAqgUEQ==
+
+"@ethersproject/networks@5.4.2", "@ethersproject/networks@^5.4.0":
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.4.2.tgz#2247d977626e97e2c3b8ee73cd2457babde0ce35"
+  integrity sha512-eekOhvJyBnuibfJnhtK46b8HimBc5+4gqpvd1/H9LEl7Q7/qhsIhM81dI9Fcnjpk3jB1aTy6bj0hz3cifhNeYw==
+  dependencies:
+    "@ethersproject/logger" "^5.4.0"
+
+"@ethersproject/pbkdf2@5.4.0", "@ethersproject/pbkdf2@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/pbkdf2/-/pbkdf2-5.4.0.tgz#ed88782a67fda1594c22d60d0ca911a9d669641c"
+  integrity sha512-x94aIv6tiA04g6BnazZSLoRXqyusawRyZWlUhKip2jvoLpzJuLb//KtMM6PEovE47pMbW+Qe1uw+68ameJjB7g==
+  dependencies:
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/sha2" "^5.4.0"
+
+"@ethersproject/properties@5.4.0", "@ethersproject/properties@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.4.0.tgz#38ba20539b44dcc5d5f80c45ad902017dcdbefe7"
+  integrity sha512-7jczalGVRAJ+XSRvNA6D5sAwT4gavLq3OXPuV/74o3Rd2wuzSL035IMpIMgei4CYyBdialJMrTqkOnzccLHn4A==
+  dependencies:
+    "@ethersproject/logger" "^5.4.0"
+
+"@ethersproject/providers@5.4.3":
+  version "5.4.3"
+  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.4.3.tgz#4cd7ccd9e12bc3875b33df8b24abf735663958a5"
+  integrity sha512-VURwkaWPoUj7jq9NheNDT5Iyy64Qcyf6BOFDwVdHsmLmX/5prNjFrgSX3GHPE4z1BRrVerDxe2yayvXKFm/NNg==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.4.0"
+    "@ethersproject/abstract-signer" "^5.4.0"
+    "@ethersproject/address" "^5.4.0"
+    "@ethersproject/basex" "^5.4.0"
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/constants" "^5.4.0"
+    "@ethersproject/hash" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/networks" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/random" "^5.4.0"
+    "@ethersproject/rlp" "^5.4.0"
+    "@ethersproject/sha2" "^5.4.0"
+    "@ethersproject/strings" "^5.4.0"
+    "@ethersproject/transactions" "^5.4.0"
+    "@ethersproject/web" "^5.4.0"
+    bech32 "1.1.4"
+    ws "7.4.6"
+
+"@ethersproject/random@5.4.0", "@ethersproject/random@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.4.0.tgz#9cdde60e160d024be39cc16f8de3b9ce39191e16"
+  integrity sha512-pnpWNQlf0VAZDEOVp1rsYQosmv2o0ITS/PecNw+mS2/btF8eYdspkN0vIXrCMtkX09EAh9bdk8GoXmFXM1eAKw==
+  dependencies:
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+
+"@ethersproject/rlp@5.4.0", "@ethersproject/rlp@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.4.0.tgz#de61afda5ff979454e76d3b3310a6c32ad060931"
+  integrity sha512-0I7MZKfi+T5+G8atId9QaQKHRvvasM/kqLyAH4XxBCBchAooH2EX5rL9kYZWwcm3awYV+XC7VF6nLhfeQFKVPg==
+  dependencies:
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+
+"@ethersproject/sha2@5.4.0", "@ethersproject/sha2@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.4.0.tgz#c9a8db1037014cbc4e9482bd662f86c090440371"
+  integrity sha512-siheo36r1WD7Cy+bDdE1BJ8y0bDtqXCOxRMzPa4bV1TGt/eTUUt03BHoJNB6reWJD8A30E/pdJ8WFkq+/uz4Gg==
+  dependencies:
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    hash.js "1.1.7"
+
+"@ethersproject/signing-key@5.4.0", "@ethersproject/signing-key@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.4.0.tgz#2f05120984e81cf89a3d5f6dec5c68ee0894fbec"
+  integrity sha512-q8POUeywx6AKg2/jX9qBYZIAmKSB4ubGXdQ88l40hmATj29JnG5pp331nAWwwxPn2Qao4JpWHNZsQN+bPiSW9A==
+  dependencies:
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    bn.js "^4.11.9"
+    elliptic "6.5.4"
+    hash.js "1.1.7"
+
+"@ethersproject/solidity@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/solidity/-/solidity-5.4.0.tgz#1305e058ea02dc4891df18b33232b11a14ece9ec"
+  integrity sha512-XFQTZ7wFSHOhHcV1DpcWj7VXECEiSrBuv7JErJvB9Uo+KfCdc3QtUZV+Vjh/AAaYgezUEKbCtE6Khjm44seevQ==
+  dependencies:
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/keccak256" "^5.4.0"
+    "@ethersproject/sha2" "^5.4.0"
+    "@ethersproject/strings" "^5.4.0"
+
+"@ethersproject/strings@5.4.0", "@ethersproject/strings@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.4.0.tgz#fb12270132dd84b02906a8d895ae7e7fa3d07d9a"
+  integrity sha512-k/9DkH5UGDhv7aReXLluFG5ExurwtIpUfnDNhQA29w896Dw3i4uDTz01Quaptbks1Uj9kI8wo9tmW73wcIEaWA==
+  dependencies:
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/constants" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+
+"@ethersproject/transactions@5.4.0", "@ethersproject/transactions@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.4.0.tgz#a159d035179334bd92f340ce0f77e83e9e1522e0"
+  integrity sha512-s3EjZZt7xa4BkLknJZ98QGoIza94rVjaEed0rzZ/jB9WrIuu/1+tjvYCWzVrystXtDswy7TPBeIepyXwSYa4WQ==
+  dependencies:
+    "@ethersproject/address" "^5.4.0"
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/constants" "^5.4.0"
+    "@ethersproject/keccak256" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/rlp" "^5.4.0"
+    "@ethersproject/signing-key" "^5.4.0"
+
+"@ethersproject/units@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/units/-/units-5.4.0.tgz#d57477a4498b14b88b10396062c8cbbaf20c79fe"
+  integrity sha512-Z88krX40KCp+JqPCP5oPv5p750g+uU6gopDYRTBGcDvOASh6qhiEYCRatuM/suC4S2XW9Zz90QI35MfSrTIaFg==
+  dependencies:
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/constants" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+
+"@ethersproject/wallet@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/wallet/-/wallet-5.4.0.tgz#fa5b59830b42e9be56eadd45a16a2e0933ad9353"
+  integrity sha512-wU29majLjM6AjCjpat21mPPviG+EpK7wY1+jzKD0fg3ui5fgedf2zEu1RDgpfIMsfn8fJHJuzM4zXZ2+hSHaSQ==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.4.0"
+    "@ethersproject/abstract-signer" "^5.4.0"
+    "@ethersproject/address" "^5.4.0"
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/hash" "^5.4.0"
+    "@ethersproject/hdnode" "^5.4.0"
+    "@ethersproject/json-wallets" "^5.4.0"
+    "@ethersproject/keccak256" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/random" "^5.4.0"
+    "@ethersproject/signing-key" "^5.4.0"
+    "@ethersproject/transactions" "^5.4.0"
+    "@ethersproject/wordlists" "^5.4.0"
+
+"@ethersproject/web@5.4.0", "@ethersproject/web@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.4.0.tgz#49fac173b96992334ed36a175538ba07a7413d1f"
+  integrity sha512-1bUusGmcoRLYgMn6c1BLk1tOKUIFuTg8j+6N8lYlbMpDesnle+i3pGSagGNvwjaiLo4Y5gBibwctpPRmjrh4Og==
+  dependencies:
+    "@ethersproject/base64" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/strings" "^5.4.0"
+
+"@ethersproject/wordlists@5.4.0", "@ethersproject/wordlists@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/wordlists/-/wordlists-5.4.0.tgz#f34205ec3bbc9e2c49cadaee774cf0b07e7573d7"
+  integrity sha512-FemEkf6a+EBKEPxlzeVgUaVSodU7G0Na89jqKjmWMlDB0tomoU8RlEMgUvXyqtrg8N4cwpLh8nyRnm1Nay1isA==
+  dependencies:
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/hash" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/strings" "^5.4.0"
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
@@ -632,10 +971,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@ledgerhq/cryptoassets@^5.39.1":
-  version "5.39.1"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/cryptoassets/-/cryptoassets-5.39.1.tgz#f50a1895eefa3eb65203bcb70bb68b9c9bfd3e76"
-  integrity sha512-CDCR+9p4V0zqwzAjAwvbBZBr+TxTmlrRYl94w4tjrxJJmNyjFefP81uZKri7oJZPxD/T8DYFlN2NPL+54WB9WQ==
+"@ledgerhq/cryptoassets@^6.4.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/cryptoassets/-/cryptoassets-6.4.0.tgz#21a620069ee569a8aad397a280081d1ff8fae58c"
+  integrity sha512-x9WVlz4zmDdfpAuMhmf9KxA74+jqD78ygwHZu61PQ8Wk15vERKx+NXFduG+JIb1jpQ1zPB0QiN4wpXPP1dRZcw==
   dependencies:
     invariant "2"
 
@@ -648,36 +987,38 @@
     "@ledgerhq/logs" "^5.22.0"
     rxjs "^6.6.2"
 
-"@ledgerhq/devices@^5.39.1":
-  version "5.39.1"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/devices/-/devices-5.39.1.tgz#9f9a2d374cdf2814ecbd9cb8317a9fa0d402d477"
-  integrity sha512-nkIgbZ3VtRPboL+BzJZi7MgSwrwhatJhSMzv63wGiJjgwgFRniMn7P0NvT0EqfMicnQMGdIKGmcB6Wdr3GLSdg==
+"@ledgerhq/devices@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/devices/-/devices-6.3.0.tgz#7ee59614198882311d1805912e368451527d05b2"
+  integrity sha512-DmVxqMAf3FhkpKjkbBCFVJ5DmesfplujeCLzFwO/zF5VGuwY7xxPqeSxlpusXJkqhEq+DbFzIDRWJYDf7rtXqg==
   dependencies:
-    "@ledgerhq/errors" "^5.39.0"
-    "@ledgerhq/logs" "^5.39.0"
-    rxjs "^6.6.3"
-    semver "^7.3.4"
+    "@ledgerhq/errors" "^6.2.0"
+    "@ledgerhq/logs" "^6.2.0"
+    rxjs "6"
+    semver "^7.3.5"
 
 "@ledgerhq/errors@^5.19.1", "@ledgerhq/errors@^5.22.0":
   version "5.22.0"
   resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-5.22.0.tgz#7327fc152d4896ddc26aada0943065db21c14880"
   integrity sha512-XDT0meBn39+q+JWzUFXmiFbVYLTy+uHRFMb9napcxyZ0Q/MdKkle9/vkgtvRHjPIkGobklXpyefsgH3BZQHukA==
 
-"@ledgerhq/errors@^5.39.0":
-  version "5.39.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-5.39.0.tgz#1fc392af94c1c1dc12d5e865b44f34bdfbc37503"
-  integrity sha512-N4/0NO2qgRlF+6QG9a4kGurmi2p6rcYyWeJb4QxU8ypGqBgzMBYjx0LM68JfGFAN5niAuqHZtDZ87EPSrXyu6Q==
+"@ledgerhq/errors@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-6.2.0.tgz#7dc2b3bf6bdedccdaa1b97dccacfa912c4fc22f8"
+  integrity sha512-eO03x8HJmG60WtlrMuahigW/rwywFdcGzCnihta/MjkM8BD9A660cKVkyIuheCcpaB7UV/r+QsRl9abHbjjaag==
 
-"@ledgerhq/hw-app-eth@5.39.1":
-  version "5.39.1"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-eth/-/hw-app-eth-5.39.1.tgz#1faca0050b401d29515a9711b69a0c718b6dac01"
-  integrity sha512-XvS0Xh0z2JG8Uq/hCEm9IVjAwK8yypDXBfEBezLNNnjPBUnVNt0YovpD2shKHquVKwTyVigpHVFqm8BXnoOOLQ==
+"@ledgerhq/hw-app-eth@^6.4.1":
+  version "6.4.1"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-eth/-/hw-app-eth-6.4.1.tgz#8153f398b1acfa365dcfdf21b4f94657f0f68ce6"
+  integrity sha512-4ycLGqvWAwH9yAeiue0jTXJEZQP7APuezoBpBlxeRtqhhFdWV6hMtbFmtTs0YvFPBrT7H0H6qylgi2oN8OaVtA==
   dependencies:
-    "@ledgerhq/cryptoassets" "^5.39.1"
-    "@ledgerhq/errors" "^5.39.0"
-    "@ledgerhq/hw-transport" "^5.39.1"
+    "@ledgerhq/cryptoassets" "^6.4.0"
+    "@ledgerhq/errors" "^6.2.0"
+    "@ledgerhq/hw-transport" "^6.3.0"
+    "@ledgerhq/logs" "^6.2.0"
+    axios "^0.21.1"
     bignumber.js "^9.0.1"
-    rlp "^2.2.6"
+    ethers "^5.4.4"
 
 "@ledgerhq/hw-transport-node-hid-noevents@^5.22.0":
   version "5.22.0"
@@ -723,24 +1064,24 @@
     "@ledgerhq/errors" "^5.22.0"
     events "^3.2.0"
 
-"@ledgerhq/hw-transport@^5.39.1":
-  version "5.39.1"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-5.39.1.tgz#03d30ede8b80357b05f17043781e4a93688374e2"
-  integrity sha512-+V+0KU4hJ/yVpF0zqsCGyFruD3Mfkz0JkkrjZIxPSaB6NWRKoeFcJNItEnER4x/wSpwROc+Jw3DYB0PXT0M6PQ==
+"@ledgerhq/hw-transport@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-6.3.0.tgz#4fc966b1a68c991c0a6b5384841f99c4f8304ce9"
+  integrity sha512-kdnVrgmxrFtKaRdkoaQBEa02RXgLzEBiooYbxA65BGSJig3PGWDS9LrqNpzLTZM1RQlivd9NLBmfwU2ze4chWA==
   dependencies:
-    "@ledgerhq/devices" "^5.39.1"
-    "@ledgerhq/errors" "^5.39.0"
-    events "^3.2.0"
+    "@ledgerhq/devices" "^6.3.0"
+    "@ledgerhq/errors" "^6.2.0"
+    events "^3.3.0"
 
 "@ledgerhq/logs@^5.19.1", "@ledgerhq/logs@^5.22.0":
   version "5.22.0"
   resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-5.22.0.tgz#a54d6b5b391cdb4c2eacc9500feb04b90475c361"
   integrity sha512-jV4mJxD1aieORm+sK9bYakQd9GMLd7KAxgt2IaxhrTU+QD5Ne47mxQOTys9p7f5w25ujs3R+Px2t3KiMRASHtg==
 
-"@ledgerhq/logs@^5.39.0":
-  version "5.39.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-5.39.0.tgz#a02678ebd43a52eb075e0344b046da9a22f95069"
-  integrity sha512-kkVtWPCss5DiizQeVMMWHhlDnF9Lft8nbIUpJsRXgiCYh4Avjsx6wYS0fiZRpRla6ki67aXRJWSnKCohH0F3BA==
+"@ledgerhq/logs@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-6.2.0.tgz#9fb2d6f1811316697f7b3cc14607f6c608912419"
+  integrity sha512-SLyFyD7ElMhgKWPYedFGCT/ilcbGPgL5hXXYHxOM79Fs5fWi0zaUpt5oGqGMsOAAFaMa9/rbun0pokzPhEFz8A==
 
 "@octokit/auth-token@^2.4.0":
   version "2.4.2"
@@ -1028,6 +1369,11 @@ acorn@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.0.tgz#e1ad486e6c54501634c6c397c5c121daa383607c"
   integrity sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==
 
+aes-js@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/aes-js/-/aes-js-3.0.0.tgz#e21df10ad6c2053295bcbb8dab40b09dbea87e4d"
+  integrity sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0=
+
 ajv@^6.10.2, ajv@^6.12.3:
   version "6.12.4"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.4.tgz#0614facc4522127fa713445c6bfd3ebd376e2234"
@@ -1281,6 +1627,13 @@ aws4@^1.8.0:
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.10.1.tgz#e1e82e4f3e999e2cfd61b161280d16a111f86428"
   integrity sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==
+
+axios@^0.21.1:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
+  dependencies:
+    follow-redirects "^1.10.0"
 
 babel-cli@^6.26.0:
   version "6.26.0"
@@ -2197,6 +2550,11 @@ bcrypto@^5.3.0:
   dependencies:
     bufio "~1.0.7"
     loady "~0.0.5"
+
+bech32@1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
+  integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
 
 before-after-hook@^2.0.0:
   version "2.1.0"
@@ -3186,7 +3544,7 @@ electron-to-chromium@^1.3.47:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.554.tgz#11d0619b927a25f300b787ad7ee1ece91384dde9"
   integrity sha512-Vtz2dVH5nMtKK4brahmgScwFS8PBnpA4VObYXtlsqN8ZpT9IFelv0Rpflc1+NIILjGVaj6vEiXQbhrs3Pl8O7g==
 
-elliptic@^6.5.2:
+elliptic@6.5.4, elliptic@^6.5.2:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
   integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==
@@ -3394,6 +3752,42 @@ ethereumjs-util@^7.1.0:
     ethjs-util "0.1.6"
     rlp "^2.2.4"
 
+ethers@^5.4.4:
+  version "5.4.4"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.4.4.tgz#35cce530505b84c699da944162195cfb3f894947"
+  integrity sha512-zaTs8yaDjfb0Zyj8tT6a+/hEkC+kWAA350MWRp6yP5W7NdGcURRPMOpOU+6GtkfxV9wyJEShWesqhE/TjdqpMA==
+  dependencies:
+    "@ethersproject/abi" "5.4.0"
+    "@ethersproject/abstract-provider" "5.4.1"
+    "@ethersproject/abstract-signer" "5.4.1"
+    "@ethersproject/address" "5.4.0"
+    "@ethersproject/base64" "5.4.0"
+    "@ethersproject/basex" "5.4.0"
+    "@ethersproject/bignumber" "5.4.1"
+    "@ethersproject/bytes" "5.4.0"
+    "@ethersproject/constants" "5.4.0"
+    "@ethersproject/contracts" "5.4.1"
+    "@ethersproject/hash" "5.4.0"
+    "@ethersproject/hdnode" "5.4.0"
+    "@ethersproject/json-wallets" "5.4.0"
+    "@ethersproject/keccak256" "5.4.0"
+    "@ethersproject/logger" "5.4.0"
+    "@ethersproject/networks" "5.4.2"
+    "@ethersproject/pbkdf2" "5.4.0"
+    "@ethersproject/properties" "5.4.0"
+    "@ethersproject/providers" "5.4.3"
+    "@ethersproject/random" "5.4.0"
+    "@ethersproject/rlp" "5.4.0"
+    "@ethersproject/sha2" "5.4.0"
+    "@ethersproject/signing-key" "5.4.0"
+    "@ethersproject/solidity" "5.4.0"
+    "@ethersproject/strings" "5.4.0"
+    "@ethersproject/transactions" "5.4.0"
+    "@ethersproject/units" "5.4.0"
+    "@ethersproject/wallet" "5.4.0"
+    "@ethersproject/web" "5.4.0"
+    "@ethersproject/wordlists" "5.4.0"
+
 ethjs-util@0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/ethjs-util/-/ethjs-util-0.1.6.tgz#f308b62f185f9fe6237132fb2a9818866a5cd536"
@@ -3411,6 +3805,11 @@ events@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.2.0.tgz#93b87c18f8efcd4202a461aec4dfc0556b639379"
   integrity sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==
+
+events@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
+  integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
 
 evp_bytestokey@^1.0.3:
   version "1.0.3"
@@ -3784,6 +4183,11 @@ flowgen@^1.9.0:
     shelljs "^0.8.4"
     typescript "^3.4"
     typescript-compiler "^1.4.1-2"
+
+follow-redirects@^1.10.0:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.1.tgz#d9114ded0a1cfdd334e164e6662ad02bfd91ff43"
+  integrity sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
@@ -4169,7 +4573,7 @@ hash-base@^3.0.0:
     readable-stream "^3.6.0"
     safe-buffer "^5.2.0"
 
-hash.js@^1.0.0, hash.js@^1.0.3, hash.js@^1.1.7:
+hash.js@1.1.7, hash.js@^1.0.0, hash.js@^1.0.3, hash.js@^1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
   integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
@@ -5244,6 +5648,11 @@ jest@^26.4.1:
     "@jest/core" "^26.4.2"
     import-local "^3.0.2"
     jest-cli "^26.4.2"
+
+js-sha3@0.5.7:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.5.7.tgz#0d4ffd8002d5333aabaf4a23eed2f6374c9f28e7"
+  integrity sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=
 
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
@@ -6993,7 +7402,7 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-rlp@2.2.6, rlp@^2.2.4, rlp@^2.2.6:
+rlp@2.2.6, rlp@^2.2.4:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/rlp/-/rlp-2.2.6.tgz#c80ba6266ac7a483ef1e69e8e2f056656de2fb2c"
   integrity sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==
@@ -7010,17 +7419,17 @@ run-async@^2.2.0:
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
   integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
 
+rxjs@6:
+  version "6.6.7"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
+  integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
+  dependencies:
+    tslib "^1.9.0"
+
 rxjs@^6.5.3, rxjs@^6.6.0, rxjs@^6.6.2:
   version "6.6.2"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.2.tgz#8096a7ac03f2cc4fe5860ef6e572810d9e01c0d2"
   integrity sha512-BHdBMVoWC2sL26w//BCu3YzKT4s2jip/WhwsGEDmeKYBhKDZeYezVUnHatYB7L85v5xs0BAQmg6BEYJEKxBabg==
-  dependencies:
-    tslib "^1.9.0"
-
-rxjs@^6.6.3:
-  version "6.6.3"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.3.tgz#8ca84635c4daa900c0d3967a6ee7ac60271ee552"
-  integrity sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==
   dependencies:
     tslib "^1.9.0"
 
@@ -7076,7 +7485,7 @@ scheduler@^0.18.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
-scrypt-js@^3.0.0:
+scrypt-js@3.0.1, scrypt-js@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-3.0.1.tgz#d314a57c2aef69d1ad98a138a21fe9eafa9ee312"
   integrity sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==
@@ -7100,7 +7509,7 @@ semver@^6.0.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.3.2, semver@^7.3.4:
+semver@^7.3.2, semver@^7.3.5:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
@@ -8271,6 +8680,11 @@ write-file-atomic@^3.0.0, write-file-atomic@^3.0.1:
     is-typedarray "^1.0.0"
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
+
+ws@7.4.6:
+  version "7.4.6"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
+  integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
 
 ws@^7.2.3:
   version "7.5.3"

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -429,20 +429,21 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@ethereumjs/common@2.0.0", "@ethereumjs/common@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@ethereumjs/common/-/common-2.0.0.tgz#096880b144ed201ca1bc213333afc473758f50dc"
-  integrity sha512-yL0zA7Xwgz8IFHKW0VoXGjdZDVxUJg8BQ/muMHvYPW7zHJNNC80gQmvLH+MpvIg1TCXZkFXxrpYRAyCElSm+aw==
+"@ethereumjs/common@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/common/-/common-2.4.0.tgz#2d67f6e6ba22246c5c89104e6b9a119fb3039766"
+  integrity sha512-UdkhFWzWcJCZVsj1O/H8/oqj/0RVYjLc1OhPjBrQdALAkQHpCp8xXI4WLnuGTADqTdJZww0NtgwG+TRPkXt27w==
   dependencies:
     crc-32 "^1.2.0"
+    ethereumjs-util "^7.1.0"
 
-"@ethereumjs/tx@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@ethereumjs/tx/-/tx-3.0.0.tgz#8dfd91ed6e91e63996e37b3ddc340821ebd48c81"
-  integrity sha512-H9tfy6qgYxPXvt1TSObfVmVjlF43OoQqoPQ3PJsG2JiuqaMHj5ettV1pGFEC3FamENDBkl6vD6niQEvIlXv/VQ==
+"@ethereumjs/tx@^3.2.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/tx/-/tx-3.3.0.tgz#14ed1b7fa0f28e1cd61e3ecbdab824205f6a4378"
+  integrity sha512-yTwEj2lVzSMgE6Hjw9Oa1DZks/nKTWM8Wn4ykDNapBPua2f4nXO3qKnni86O6lgDj5fVNRqbDsD0yy7/XNGDEA==
   dependencies:
-    "@ethereumjs/common" "^2.0.0"
-    ethereumjs-util "^7.0.7"
+    "@ethereumjs/common" "^2.4.0"
+    ethereumjs-util "^7.1.0"
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
@@ -896,13 +897,6 @@
   integrity sha512-i+zS7t6/s9cdQvbqKDARrcbrPvtJGlbYsMkazo03nTAK3RX9FNrLllXys22uiTGJapPOTZTQ35nHh4ISph4SLQ==
   dependencies:
     "@babel/types" "^7.3.0"
-
-"@types/bn.js@^4.11.3":
-  version "4.11.6"
-  resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-4.11.6.tgz#c306c70d9358aaea33cd4eda092a742b9505967c"
-  integrity sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==
-  dependencies:
-    "@types/node" "*"
 
 "@types/bn.js@^5.1.0":
   version "5.1.0"
@@ -2719,6 +2713,15 @@ cliui@^6.0.0:
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
 
+cliui@^7.0.2:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
+  integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
+
 clone-response@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/clone-response/-/clone-response-1.0.2.tgz#d1dc973920314df67fbeb94223b4ee350239e96b"
@@ -3274,6 +3277,11 @@ es6-error@^4.0.1:
   resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.1.1.tgz#9e3af407459deed47e9a91f9b885a84eb05c561d"
   integrity sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==
 
+escalade@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
+  integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
+
 escape-string-regexp@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
@@ -3374,12 +3382,12 @@ ethereumjs-util@^7.0.10:
     ethjs-util "0.1.6"
     rlp "^2.2.4"
 
-ethereumjs-util@^7.0.7:
-  version "7.0.7"
-  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-7.0.7.tgz#484fb9c03b766b2ee64821281070616562fb5a59"
-  integrity sha512-vU5rtZBlZsgkTw3o6PDKyB8li2EgLavnAbsKcfsH2YhHH1Le+PP8vEiMnAnvgc1B6uMoaM5GDCrVztBw0Q5K9g==
+ethereumjs-util@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-7.1.0.tgz#e2b43a30bfcdbcb432a4eb42bd5f2393209b3fd5"
+  integrity sha512-kR+vhu++mUDARrsMMhsjjzPduRVAeundLGXucGRHF3B4oEltOUspfgCVco4kckucj3FMlLaZHUl9n7/kdmr6Tw==
   dependencies:
-    "@types/bn.js" "^4.11.3"
+    "@types/bn.js" "^5.1.0"
     bn.js "^5.1.2"
     create-hash "^1.1.2"
     ethereum-cryptography "^0.1.3"
@@ -3929,7 +3937,7 @@ get-caller-file@^1.0.1:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
   integrity sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
 
-get-caller-file@^2.0.1:
+get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
@@ -8231,6 +8239,15 @@ wrap-ansi@^6.2.0:
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
 
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -8274,6 +8291,11 @@ xmlchars@^2.2.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
+
+y18n@^5.0.5:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
+  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
 yallist@^2.1.2:
   version "2.1.2"
@@ -8334,6 +8356,11 @@ yargs-parser@^18.1.2:
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
+
+yargs-parser@^20.2.2:
+  version "20.2.9"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
+  integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
 yargs-unparser@1.6.1:
   version "1.6.1"
@@ -8430,6 +8457,19 @@ yargs@^15.0.1, yargs@^15.3.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
+
+yargs@^17.1.0:
+  version "17.1.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.1.0.tgz#0cd9827a0572c9a1795361c4d1530e53ada168cf"
+  integrity sha512-SQr7qqmQ2sNijjJGHL4u7t8vyDZdZ3Ahkmo4sc1w5xI9TBX0QDdG/g4SFnxtWOsGLjwHQue57eFALfwFCnixgg==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.5"
+    yargs-parser "^20.2.2"
 
 yn@3.1.1:
   version "3.1.1"


### PR DESCRIPTION
## Summary
Upcoming network upgrades mean that applications will start sending EIP-1559-style transactions to the Ledger. This PR proposes to add handling for these transactions. This maintains backwards compatibility with old legacy-style transactions. 

## Testing
Unit tests pass, see `eth-tests.js:250` or so. E2E testing in progress (wanted to get the PR up ASAP). 

### See Also
[EIP-1559 standard ](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1559.md)