### PR TITLE
[DRAFT] Move to a single-confirm UX for txn confirmations.

### DIFF
--- a/tests/basic-tests.js
+++ b/tests/basic-tests.js
@@ -153,10 +153,10 @@ describe("Basic Tests", () => {
       const pathPrefix = "44'/9000'/0'";
       const pathSuffixes = ["0/0", "0/1", "1/100"];
       const ui = await flowMultiPrompt(this.speculos, [
-        [{header:"Sign",body:"Transaction"}],
-        [{header:"Transfer",body:"0.000012345 AVAX to fuji12yp9cc0melq83a5nxnurf0nd6fk4t224unmnwx"}],
-        [{header:"Fee",body:"0.123444444 AVAX"}],
-        [{header:"Finalize",body:"Transaction"}],
+        {header:"Sign",body:"Transaction"},
+        {header:"Transfer",body:"0.000012345 AVAX to fuji12yp9cc0melq83a5nxnurf0nd6fk4t224unmnwx"},
+        {header:"Fee",body:"0.123444444 AVAX"},
+        {header:"Finalize",body:"Transaction"},
       ]);
       const sigPromise = signTransaction(this.ava, pathPrefix, pathSuffixes);
       await ui.promptsPromise;
@@ -167,10 +167,10 @@ describe("Basic Tests", () => {
       const pathPrefix = "44'/9000'/0'";
       const pathSuffixes = ["0/0", "0/1", "1/100"];
       const ui = await flowMultiPrompt(this.speculos, [
-        [{header:"Sign",body:"Transaction"}],
-        [{header:"Transfer",body:"0.123456789 AVAX to fuji12yp9cc0melq83a5nxnurf0nd6fk4t224unmnwx"}],
-        [{header:"Fee",body:"0.876543211 AVAX"}],
-        [{header:"Finalize",body:"Transaction"}],
+        {header:"Sign",body:"Transaction"},
+        {header:"Transfer",body:"0.123456789 AVAX to fuji12yp9cc0melq83a5nxnurf0nd6fk4t224unmnwx"},
+        {header:"Fee",body:"0.876543211 AVAX"},
+        {header:"Finalize",body:"Transaction"},
       ]);
       const sigPromise = signTransaction(this.ava, pathPrefix, pathSuffixes, {
         "outputAmount": Buffer.from([0x00, 0x00, 0x00, 0x00, 0x07, 0x5b, 0xcd, 0x15]),
@@ -184,10 +184,10 @@ describe("Basic Tests", () => {
       const pathPrefix = "44'/9000'/0'";
       const pathSuffixes = ["0/0", "0/1", "1/100"];
       const ui = await flowMultiPrompt(this.speculos, [
-        [{header:"Sign",body:"Transaction"}],
-        [{header:"Transfer",body:"1 AVAX to fuji12yp9cc0melq83a5nxnurf0nd6fk4t224unmnwx"}],
-        [{header:"Fee",body:"1 AVAX"}],
-        [{header:"Finalize",body:"Transaction"}],
+        {header:"Sign",body:"Transaction"},
+        {header:"Transfer",body:"1 AVAX to fuji12yp9cc0melq83a5nxnurf0nd6fk4t224unmnwx"},
+        {header:"Fee",body:"1 AVAX"},
+        {header:"Finalize",body:"Transaction"},
       ]);
       const sigPromise = signTransaction(this.ava, pathPrefix, pathSuffixes, {
         "outputAmount": Buffer.from([0x00, 0x00, 0x00, 0x00, 0x3b, 0x9a, 0xca, 0x00]),
@@ -277,11 +277,11 @@ describe("Basic Tests", () => {
       const pathPrefix = "44'/9000'/0'";
       const pathSuffixes = ["0/0", "0/1", "1/100"];
       const ui = await flowMultiPrompt(this.speculos, [
-        [{header:"Sign",body:"Transaction"}],
-        [{header:"Transfer",body:"0.000001 AVAX to fuji10an3cucdfqru984pnvv6y0rspvvclz634xwwhs"}],
-        [{header:"Transfer",body:"0.006999 AVAX to fuji15jh6hlessx2jtxvs48jnr0vzxrg34x32vuc7jc"}],
-        [{header:"Fee",body:"0.001 AVAX"}],
-        [{header:"Finalize",body:"Transaction"}],
+        {header:"Sign",body:"Transaction"},
+        {header:"Transfer",body:"0.000001 AVAX to fuji10an3cucdfqru984pnvv6y0rspvvclz634xwwhs"},
+        {header:"Transfer",body:"0.006999 AVAX to fuji15jh6hlessx2jtxvs48jnr0vzxrg34x32vuc7jc"},
+        {header:"Fee",body:"0.001 AVAX"},
+        {header:"Finalize",body:"Transaction"},
       ]);
       const sigPromise = this.ava.signTransaction(
         BIPPath.fromString(pathPrefix),
@@ -372,11 +372,11 @@ describe("Basic Tests", () => {
       const pathPrefix = "44'/9000'/0'";
       const pathSuffixes = ["0/0", "0/1", "1/100"];
       const ui = await flowMultiPrompt(this.speculos, [
-        [{header:"Sign",body:"Transaction"}],
-        [{header:"Transfer",body:"0.000001 AVAX to fuji10an3cucdfqru984pnvv6y0rspvvclz634xwwhs"}],
-        [{header:"Transfer",body:"0.006999 AVAX to fuji179xfr036ym3uuv8ewrv8y4la97ealwmlfg8yrr"}],
-        [{header:"Fee",body:"0.001 AVAX"}],
-        [{header:"Finalize",body:"Transaction"}],
+        {header:"Sign",body:"Transaction"},
+        {header:"Transfer",body:"0.000001 AVAX to fuji10an3cucdfqru984pnvv6y0rspvvclz634xwwhs"},
+        {header:"Transfer",body:"0.006999 AVAX to fuji179xfr036ym3uuv8ewrv8y4la97ealwmlfg8yrr"},
+        {header:"Fee",body:"0.001 AVAX"},
+        {header:"Finalize",body:"Transaction"},
       ]);
       const sigPromise = this.ava.signTransaction(
         BIPPath.fromString(pathPrefix),
@@ -391,9 +391,9 @@ describe("Basic Tests", () => {
     it('rejects a transaction that has extra data', async function () {
       try {
         const ui = await flowMultiPrompt(this.speculos, [
-          [{header:"Sign",body:"Transaction"}],
-          [{header:"Transfer",body:"0.000012345 AVAX to fuji12yp9cc0melq83a5nxnurf0nd6fk4t224unmnwx"}],
-          [{header:"Fee",body:"0.123444444 AVAX"}],
+          {header:"Sign",body:"Transaction"},
+          {header:"Transfer",body:"0.000012345 AVAX to fuji12yp9cc0melq83a5nxnurf0nd6fk4t224unmnwx"},
+          {header:"Fee",body:"0.123444444 AVAX"},
         ], "Next", "Next");
         await signTransaction(this.ava, "44'/9000'/0'", ["0/0"], {
           extraEndBytes: Buffer.from([0x00])
@@ -446,7 +446,7 @@ describe("Basic Tests", () => {
         this.speculos,
         this.ava,
         { outputTypeId: Buffer.from([0x00, 0x00, 0xf0, 0x00]) },
-        [[{header:"Sign",body:"Transaction"}]],
+        [{header:"Sign",body:"Transaction"}],
       );
     });
 
@@ -456,8 +456,8 @@ describe("Basic Tests", () => {
         this.ava,
         { inputTypeId: Buffer.from([0x01, 0x00, 0x00, 0x00]) },
         [
-          [{header:"Sign",body:"Transaction"}],
-          [{header:"Transfer",body:"0.000012345 AVAX to fuji12yp9cc0melq83a5nxnurf0nd6fk4t224unmnwx"}],
+          {header:"Sign",body:"Transaction"},
+          {header:"Transfer",body:"0.000012345 AVAX to fuji12yp9cc0melq83a5nxnurf0nd6fk4t224unmnwx"},
         ],
       );
     });
@@ -478,7 +478,7 @@ describe("Basic Tests", () => {
           outputAssetId: assetId
         },
         [
-          [{header:"Sign",body:"Transaction"}],
+          {header:"Sign",body:"Transaction"},
         ],
       );
     });
@@ -499,7 +499,7 @@ describe("Basic Tests", () => {
          outputAssetId: assetId
        },
        [
-         [{header:"Sign",body:"Transaction"}],
+         {header:"Sign",body:"Transaction"},
        ],
      );
    });
@@ -523,7 +523,7 @@ describe("Basic Tests", () => {
        this.ava,
        { transferrableOutput: output },
        [
-         [{header:"Sign",body:"Transaction"}],
+         {header:"Sign",body:"Transaction"},
        ],
      );
     });
@@ -600,11 +600,11 @@ describe("Basic Tests", () => {
 
     it("Can sign a P->X Import transaction", async function() {
       const ui = await flowMultiPrompt(this.speculos, [
-        [{header:"Sign",body:"Import"}],
-        [{header:"Sending",body: "0.000012345 AVAX to fuji1cv6yz28qvqfgah34yw3y53su39p6kzzehw5pj3"}],
-        [{header:"From",body: "P-chain"}],
-        [{header:"Fee",body:"0.246901233 AVAX"}],
-        [{header:"Finalize",body:"Transaction"}],
+        {header:"Sign",body:"Import"},
+        {header:"Sending",body: "0.000012345 AVAX to fuji1cv6yz28qvqfgah34yw3y53su39p6kzzehw5pj3"},
+        {header:"From",body: "P-chain"},
+        {header:"Fee",body:"0.246901233 AVAX"},
+        {header:"Finalize",body:"Transaction"},
       ]);
       const sigPromise = this.ava.signTransaction(
         BIPPath.fromString(pathPrefix),
@@ -617,11 +617,11 @@ describe("Basic Tests", () => {
 
     it("Can sign a C->X Import transaction", async function() {
         const ui = await flowMultiPrompt(this.speculos, [
-          [{header:"Sign",body:"Import"}],
-          [{header:"Sending",body: "0.000012345 AVAX to fuji1cv6yz28qvqfgah34yw3y53su39p6kzzehw5pj3"}],
-          [{header:"From",body: "C-chain"}],
-          [{header:"Fee",body:"0.246901233 AVAX"}],
-          [{header:"Finalize",body:"Transaction"}],
+          {header:"Sign",body:"Import"},
+          {header:"Sending",body: "0.000012345 AVAX to fuji1cv6yz28qvqfgah34yw3y53su39p6kzzehw5pj3"},
+          {header:"From",body: "C-chain"},
+          {header:"Fee",body:"0.246901233 AVAX"},
+          {header:"Finalize",body:"Transaction"},
         ]);
         const sigPromise = this.ava.signTransaction(
           BIPPath.fromString(pathPrefix),
@@ -682,11 +682,11 @@ describe("Basic Tests", () => {
 
     it("Can sign a X->P Export transaction", async function() {
       const ui = await flowMultiPrompt(this.speculos, [
-        [{header:"Sign",body:"Export"}],
-        [{header:"Transfer",body: "0.000012345 AVAX to fuji1cv6yz28qvqfgah34yw3y53su39p6kzzehw5pj3"}],
-        [{header:"X to P chain",body:"0.000012345 AVAX to fuji12yp9cc0melq83a5nxnurf0nd6fk4t224unmnwx"}],
-        [{header:"Fee",body:"0.123432099 AVAX"}],
-        [{header:"Finalize",body:"Transaction"}],
+        {header:"Sign",body:"Export"},
+        {header:"Transfer",body: "0.000012345 AVAX to fuji1cv6yz28qvqfgah34yw3y53su39p6kzzehw5pj3"},
+        {header:"X to P chain",body:"0.000012345 AVAX to fuji12yp9cc0melq83a5nxnurf0nd6fk4t224unmnwx"},
+        {header:"Fee",body:"0.123432099 AVAX"},
+        {header:"Finalize",body:"Transaction"},
       ]);
       const sigPromise = this.ava.signTransaction(
         BIPPath.fromString(pathPrefix),
@@ -699,11 +699,11 @@ describe("Basic Tests", () => {
 
     it("Can sign a X->C Export transaction", async function() {
       const ui = await flowMultiPrompt(this.speculos, [
-        [{header:"Sign",body:"Export"}],
-        [{header:"Transfer",body: "0.000012345 AVAX to fuji1cv6yz28qvqfgah34yw3y53su39p6kzzehw5pj3"}],
-        [{header:"X to C chain",body:"0.000012345 AVAX to fuji12yp9cc0melq83a5nxnurf0nd6fk4t224unmnwx"}],
-        [{header:"Fee",body:"0.123432099 AVAX"}],
-        [{header:"Finalize",body:"Transaction"}],
+        {header:"Sign",body:"Export"},
+        {header:"Transfer",body: "0.000012345 AVAX to fuji1cv6yz28qvqfgah34yw3y53su39p6kzzehw5pj3"},
+        {header:"X to C chain",body:"0.000012345 AVAX to fuji12yp9cc0melq83a5nxnurf0nd6fk4t224unmnwx"},
+        {header:"Fee",body:"0.123432099 AVAX"},
+        {header:"Finalize",body:"Transaction"},
       ]);
       const sigPromise = this.ava.signTransaction(
         BIPPath.fromString(pathPrefix),

--- a/tests/c-chain-tests.js
+++ b/tests/c-chain-tests.js
@@ -68,10 +68,10 @@ describe("C-chain import and export tests", () => {
     const pathPrefix = "44'/60'/0'";
     const pathSuffixes = ["0/0", "0/1", "100/100"];
     const ui = await flowMultiPrompt(this.speculos, [
-      [{header:"Sign", body:"Import"}],
-      [{header:"Importing",body:"0.268435456 AVAX to local1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqljssag"}],
-      [{header:"Fee", body:"0 AVAX"}],
-      [{header:"Finalize",body:"Transaction"}],
+      {header:"Sign", body:"Import"},
+      {header:"Importing",body:"0.268435456 AVAX to local1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqljssag"},
+      {header:"Fee", body:"0 AVAX"},
+      {header:"Finalize",body:"Transaction"},
     ]);
     const sigPromise = this.ava.signTransaction(
       BIPPath.fromString(pathPrefix),
@@ -129,10 +129,10 @@ describe("C-chain import and export tests", () => {
     const pathPrefix = "44'/60'/0'";
     const pathSuffixes = ["0/0", "0/1", "100/100"];
     const ui = await flowMultiPrompt(this.speculos, [
-      [{header:"Sign",body:"Export"}],
-      [{header:"C chain export",body:'0.001 AVAX to local1vmusmdsn0fu0w6ekj0ml90zs09td4etrp5d6p7'}],
-      [{header:"Fee",body:"0.001 AVAX"}],
-      [{header:"Finalize",body:"Transaction"}],
+      {header:"Sign",body:"Export"},
+      {header:"C chain export",body:'0.001 AVAX to local1vmusmdsn0fu0w6ekj0ml90zs09td4etrp5d6p7'},
+      {header:"Fee",body:"0.001 AVAX"},
+      {header:"Finalize",body:"Transaction"},
     ]);
     const sigPromise = this.ava.signTransaction(
       BIPPath.fromString(pathPrefix),
@@ -149,10 +149,10 @@ describe("C-chain import and export tests", () => {
     const pathPrefix = "44'/60'/0'";
     const pathSuffixes = ["0/0", "0/1", "100/100"];
     const ui = await flowMultiPrompt(this.speculos, [
-      [{header:"Sign",body:"Export"}],
-      [{header:"C chain export",body:'47473250 AVAX to local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u'}],
-      [{header:"Fee",body:"2526750 AVAX"}],
-      [{header:"Finalize",body:"Transaction"}],
+      {header:"Sign",body:"Export"},
+      {header:"C chain export",body:'47473250 AVAX to local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u'},
+      {header:"Fee",body:"2526750 AVAX"},
+      {header:"Finalize",body:"Transaction"},
     ]);
     const sigPromise = this.ava.signTransaction(
       BIPPath.fromString(pathPrefix),
@@ -169,10 +169,10 @@ describe("C-chain import and export tests", () => {
     const pathPrefix = "44'/60'/0'";
     const pathSuffixes = ["0/0", "0/1", "100/100"];
     const ui = await flowMultiPrompt(this.speculos, [
-      [{header:"Sign", body:"Import"}],
-      [{header:"Importing",body:"27473249 AVAX to local13kuhcl8vufyu9wvtmspzdnzv9ftm75hunmtqe9"}],
-      [{header:"Fee", body:"2526750 AVAX"}],
-      [{header:"Finalize",body:"Transaction"}],
+      {header:"Sign", body:"Import"},
+      {header:"Importing",body:"27473249 AVAX to local13kuhcl8vufyu9wvtmspzdnzv9ftm75hunmtqe9"},
+      {header:"Fee", body:"2526750 AVAX"},
+      {header:"Finalize",body:"Transaction"},
     ]);
     const sigPromise = this.ava.signTransaction(
       BIPPath.fromString(pathPrefix),

--- a/tests/eth-tests.js
+++ b/tests/eth-tests.js
@@ -39,21 +39,21 @@ const rawUnsignedEIP1559Transaction = (chainId, unsignedTxParams) => {
 const finalizePrompt = {header: "Finalize", body: "Transaction"};
 
 const transferPrompts = (address, amount, fee) => [
-    [{header: "Transfer",    body: amount + " to " + address}],
-    [{header: "Fee",         body: fee}],
-    [finalizePrompt]
+    {header: "Transfer",    body: amount + " to " + address},
+    {header: "Fee",         body: fee},
+    finalizePrompt
 ];
 
 const assetCallTransferPrompts = (assetID, address, amount) => [
-    [{header: "Transfer",    body: amount + " of " + assetID + " to " + address}],
-    [{header: "Maximum Fee", body: "47000000 GWEI"}],
-    [finalizePrompt]
+    {header: "Transfer",    body: amount + " of " + assetID + " to " + address},
+    {header: "Maximum Fee", body: "47000000 GWEI"},
+    finalizePrompt
 ];
 
 const assetCallDepositPrompts = (assetID, address, amount) => [
-    [{header: "Deposit",     body: amount + " of " + assetID + " to " + address}],
-    [{header: "Maximum Fee", body: "47000000 GWEI"}],
-    [finalizePrompt]
+    {header: "Deposit",     body: amount + " of " + assetID + " to " + address},
+    {header: "Maximum Fee", body: "47000000 GWEI"},
+    finalizePrompt
 ];
 
 const contractCallPrompts = (address, method, args) => {
@@ -61,11 +61,7 @@ const contractCallPrompts = (address, method, args) => {
     const maxFeePrompt   = {header: "Maximum Fee",   body: "10229175 GWEI"};
     const argumentPrompts = args.map(([header,body]) => [{ header, body }]);
 
-    return [].concat(
-        [[methodPrompt]],
-        argumentPrompts,
-        [[maxFeePrompt],
-         [finalizePrompt]]);
+    return [methodPrompt, argumentPrompts, maxFeePrompt, finalizePrompt];
 };
 
 const contractDeployPrompts = (bytes, amount, fee, gas) => {
@@ -74,14 +70,7 @@ const contractDeployPrompts = (bytes, amount, fee, gas) => {
   const fundingPrompt  = {header: "Funding Contract",  body: amount};
   const dataPrompt     = {header: "Data",              body: "0x60806040523480156200001157600080fd5b5060..."};
   const feePrompt      = {header: "Maximum Fee",       body: fee};
-  return [].concat(
-      [[creationPrompt, gasPrompt]],
-      amount ? [[fundingPrompt]] : [],
-      [[dataPrompt],
-       [feePrompt],
-       [finalizePrompt]
-      ]
-  );
+  return amount ? [creationPrompt, gasPrompt, fundingPrompt, dataPrompt, feePrompt, finalizePrompt] : [creationPrompt, gasPrompt, dataPrompt, feePrompt, finalizePrompt];
 };
 
 async function testLegacySigning(self, chainId, prompts, hexTx) {
@@ -139,10 +128,10 @@ const testUnrecognizedCalldataTx = (chainId, gasPrice, gasLimit, amountPrompt, a
     });
 
     const prompts =
-          [[{header: "Transfer",     body: amountPrompt + " to " + '0x' + address}],
-           [{header: "Contract Data", body: "Is Present (unsafe)"}],
-           [{header: "Maximum Fee",   body: fee}],
-           [finalizePrompt]
+          [{header: "Transfer",     body: amountPrompt + " to " + '0x' + address},
+           {header: "Contract Data", body: "Is Present (unsafe)"},
+           {header: "Maximum Fee",   body: fee},
+           finalizePrompt
           ];
 
     await testLegacySigning(this, chainId, prompts, tx);
@@ -239,10 +228,10 @@ const testData = {
       });
     
       const prompts =
-            [[{header: "Transfer",     body: '0.000004096 nAVAX' + " to " + '0x' + '0102030400000000000000000000000000000002'}],
-              [{header: "Contract Data", body: "Is Present (unsafe)"}],
-              [{header: "Maximum Fee",   body: "0.002293452 GWEI"}],
-              [finalizePrompt]
+            [ {header: "Transfer",     body: '0.000004096 nAVAX' + " to " + '0x' + '0102030400000000000000000000000000000002'},
+              {header: "Contract Data", body: "Is Present (unsafe)"},
+              {header: "Maximum Fee",   body: "0.002293452 GWEI"},
+              finalizePrompt
             ];
     
       await testEIP1559Signing(this, chainId, prompts, tx);
@@ -266,8 +255,8 @@ const testData = {
       });
     
       const prompts =
-            [[{header: "Transfer",     body: '0.000004096 nAVAX' + " to " + '0x' + '0102030400000000000000000000000000000002'}],
-              [finalizePrompt]
+            [ {header: "Transfer",     body: '0.000004096 nAVAX' + " to " + '0x' + '0102030400000000000000000000000000000002'},
+              finalizePrompt
             ];
     
       await testEIP1559Signing(this, chainId, prompts, tx);
@@ -280,9 +269,9 @@ const testData = {
     const tx = Buffer.from('02f9018a82a868808506fc23ac008506fc23ac008316e3608080b90170608060405234801561001057600080fd5b50610150806100206000396000f3fe608060405234801561001057600080fd5b50600436106100365760003560e01c80632e64cec11461003b5780636057361d14610059575b600080fd5b610043610075565b60405161005091906100d9565b60405180910390f35b610073600480360381019061006e919061009d565b61007e565b005b60008054905090565b8060008190555050565b60008135905061009781610103565b92915050565b6000602082840312156100b3576100b26100fe565b5b60006100c184828501610088565b91505092915050565b6100d3816100f4565b82525050565b60006020820190506100ee60008301846100ca565b92915050565b6000819050919050565b600080fd5b61010c816100f4565b811461011757600080fd5b5056fea2646970667358221220404e37f487a89a932dca5e77faaf6ca2de3b991f93d230604b1b8daaef64766264736f6c63430008070033c0', 'hex');
 
     const prompts = [
-        [{ header: 'Contract', body: 'Creation' }, { header: 'Gas Limit', body: '1500000' }],
-      [ { header: 'Data', body: '0x608060405234801561001057600080fd5b506101...' } ],
-        [finalizePrompt]
+        { header: 'Contract', body: 'Creation' }, { header: 'Gas Limit', body: '1500000' },
+        { header: 'Data', body: '0x608060405234801561001057600080fd5b506101...' },
+        finalizePrompt
       ];
     await testEIP1559Signing(this, chainId, prompts, tx);
   });
@@ -328,22 +317,22 @@ const testData = {
   it('can sign a ERC20PresetMinterPauser pause contract call', testCall(43113, '8456cb59', 'pause', []));
   it('can sign a ERC20PresetMinterPauser unpause contract call', testCall(43113, '3f4ba83a', 'unpause', []));
   it('can sign a ERC20PresetMinterPauser burn contract call', testCall(43113, '42966c68' + testData.amount.hex, 'burn', [
-      ["amount", testData.amount.prompt]
+      "amount", testData.amount.prompt
   ]));
   it('can sign a ERC20PresetMinterPauser mint contract call', testCall(43113, '40c10f19' + testData.address.hex + testData.amount.hex, 'mint', [
-    ["to", '0x' + testData.address.prompt],
-    ["amount", testData.amount.prompt]
+    "to", '0x' + testData.address.prompt,
+    "amount", testData.amount.prompt
   ]));
 
   it('can sign a ERC20PresetMinterPauser transferFrom contract call', testCall(43113, '23b872dd' + testData.address.hex + testData.address.hex + testData.amount.hex, 'transferFrom', [
-    ["sender", '0x' + testData.address.prompt],
-    ["recipient", '0x' + testData.address.prompt],
-    ["amount", testData.amount.prompt]
+    "sender", '0x' + testData.address.prompt,
+    "recipient", '0x' + testData.address.prompt,
+    "amount", testData.amount.prompt
   ]));
 
   it('can sign a ERC20PresetMinterPauser grantRole contract call', testCall(43113, '2f2ff15d' + testData.bytes32 + testData.address.hex, 'grantRole', [
-      ["role", '0x' + testData.bytes32],
-      ["account", '0x' + testData.address.prompt]
+      "role", '0x' + testData.bytes32,
+      "account", '0x' + testData.address.prompt
   ]));
 
   it('can sign a transaction deploying erc20 contract without funding', testDeploy(43112, false));

--- a/tests/p-chain-tests.js
+++ b/tests/p-chain-tests.js
@@ -59,10 +59,10 @@ describe("P-chain import and export tests", () => {
     const pathPrefix = "44'/9000'/0'";
     const pathSuffixes = ["0/0", "0/1", "100/100"];
     const ui = await flowMultiPrompt(this.speculos, [
-      [{header:"Sign",body:"Import"}],
-      [{header:"P chain import",body:"19999.999 AVAX to fuji18jma8ppw3nhx5r4ap8clazz0dps7rv5u6wmu4t"}],
-      [{header:"Fee",body:"15188.373088832 AVAX"}],
-      [{header:"Finalize",body:"Transaction"}],
+      {header:"Sign",body:"Import"},
+      {header:"P chain import",body:"19999.999 AVAX to fuji18jma8ppw3nhx5r4ap8clazz0dps7rv5u6wmu4t"},
+      {header:"Fee",body:"15188.373088832 AVAX"},
+      {header:"Finalize",body:"Transaction"},
     ]);
     const sigPromise = this.ava.signTransaction(
       BIPPath.fromString(pathPrefix),
@@ -124,11 +124,11 @@ describe("P-chain import and export tests", () => {
     const pathPrefix = "44'/9000'/0'";
     const pathSuffixes = ["0/0", "0/1", "100/100"];
     const ui = await flowMultiPrompt(this.speculos, [
-      [{header:"Sign",body:"Export"}],
-      [{header:"Transfer",body:'0.000012345 AVAX to fuji1cv6yz28qvqfgah34yw3y53su39p6kzzehw5pj3'}],
-      [{header:"P chain export",body:'0.000012345 AVAX to fuji12yp9cc0melq83a5nxnurf0nd6fk4t224unmnwx'}],
-      [{header:"Fee",body:"0.123432099 AVAX"}],
-      [{header:"Finalize",body:"Transaction"}],
+      {header:"Sign",body:"Export"},
+      {header:"Transfer",body:'0.000012345 AVAX to fuji1cv6yz28qvqfgah34yw3y53su39p6kzzehw5pj3'},
+      {header:"P chain export",body:'0.000012345 AVAX to fuji12yp9cc0melq83a5nxnurf0nd6fk4t224unmnwx'},
+      {header:"Fee",body:"0.123432099 AVAX"},
+      {header:"Finalize",body:"Transaction"},
     ]);
     const sigPromise = this.ava.signTransaction(
       BIPPath.fromString(pathPrefix),
@@ -145,10 +145,10 @@ describe("P-chain import and export tests", () => {
     const pathPrefix = "44'/9000'/0'";
     const pathSuffixes = ["0/0", "0/1", "100/100"];
     const ui = await flowMultiPrompt(this.speculos, [
-      [{header:"Sign",body:"Export"}],
-      [{header:"P chain export",body:'29999999 AVAX to local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u'}],
-      [{header:"Fee",body:"1 AVAX"}],
-      [{header:"Finalize",body:"Transaction"}],
+      {header:"Sign",body:"Export"},
+      {header:"P chain export",body:'29999999 AVAX to local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u'},
+      {header:"Fee",body:"1 AVAX"},
+      {header:"Finalize",body:"Transaction"},
     ]);
     const sigPromise = this.ava.signTransaction(
       BIPPath.fromString(pathPrefix),
@@ -165,10 +165,10 @@ describe("P-chain import and export tests", () => {
     const pathPrefix = "44'/9000'/0'";
     const pathSuffixes = ["0/0", "0/1", "100/100"];
     const ui = await flowMultiPrompt(this.speculos, [
-      [{header:"Sign",body:"Import"}],
-      [{header:"Importing",body:'27473249 AVAX to local13kuhcl8vufyu9wvtmspzdnzv9ftm75hunmtqe9'}],
-      [{header:"Fee",body:"2526750 AVAX"}],
-      [{header:"Finalize",body:"Transaction"}],
+      {header:"Sign",body:"Import"},
+      {header:"Importing",body:'27473249 AVAX to local13kuhcl8vufyu9wvtmspzdnzv9ftm75hunmtqe9'},
+      {header:"Fee",body:"2526750 AVAX"},
+      {header:"Finalize",body:"Transaction"},
     ]);
     const sigPromise = this.ava.signTransaction(
       BIPPath.fromString(pathPrefix),
@@ -255,17 +255,17 @@ describe('Staking tests', async function () {
     const pathPrefix = "44'/9000'/0'";
     const pathSuffixes = ["0/0", "0/1", "100/100"];
     const ui = await flowMultiPrompt(this.speculos, [
-      [{header: 'Sign', body: 'Add Validator'}],
-      [{header: 'Transfer', body: '3.999 AVAX to local1mg47uqd7stkvqrp57ds7m28txra45u2uzkta8n'}],
-      [{header: 'Validator', body: 'NodeID-NFBbbJ4qCmNaCzeW7sxErhvWqvEQMnYcN' }],
-      [{header: 'Start time', body: '2020-07-29 22:07:25 UTC' }],
-      [{header: 'End time', body: '2020-08-28 21:57:26 UTC' }],
-      [{header: 'Total Stake', body: '2000 AVAX' }],
-      [{header: 'Stake',body: '2000 AVAX to local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u'}],
-      [{header: 'Rewards To', body: 'local1mg47uqd7stkvqrp57ds7m28txra45u2uzkta8n' }],
-      [{header: 'Delegation Fee', body: '0.01%' }],
-      [{header: 'Fee',body: '0.001 AVAX'}],
-      [{header: 'Finalize',body: 'Transaction'}],
+      {header: 'Sign', body: 'Add Validator'},
+      {header: 'Transfer', body: '3.999 AVAX to local1mg47uqd7stkvqrp57ds7m28txra45u2uzkta8n'},
+      {header: 'Validator', body: 'NodeID-NFBbbJ4qCmNaCzeW7sxErhvWqvEQMnYcN' },
+      {header: 'Start time', body: '2020-07-29 22:07:25 UTC' },
+      {header: 'End time', body: '2020-08-28 21:57:26 UTC' },
+      {header: 'Total Stake', body: '2000 AVAX' },
+      {header: 'Stake',body: '2000 AVAX to local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u'},
+      {header: 'Rewards To', body: 'local1mg47uqd7stkvqrp57ds7m28txra45u2uzkta8n' },
+      {header: 'Delegation Fee', body: '0.01%' },
+      {header: 'Fee',body: '0.001 AVAX'},
+      {header: 'Finalize',body: 'Transaction'},
     ]);
     const sigPromise = this.ava.signTransaction(
       BIPPath.fromString(pathPrefix),
@@ -350,13 +350,13 @@ describe('Staking tests', async function () {
       const pathPrefix = "44'/9000'/0'";
       const pathSuffixes = ["0/0", "0/1", "100/100"];
       const ui = await flowMultiPrompt(this.speculos, [
-        [{header: 'Sign', body: 'Add Validator'}],
-        [{header: 'Transfer', body: '3.999 AVAX to local1mg47uqd7stkvqrp57ds7m28txra45u2uzkta8n'}],
-        [{header: 'Validator', body: 'NodeID-NFBbbJ4qCmNaCzeW7sxErhvWqvEQMnYcN' }],
-        [{header: 'Start time', body: '2020-07-29 22:07:25 UTC' }],
-        [{header: 'End time', body: '2020-08-28 21:57:26 UTC' }],
-        [{header: 'Total Stake', body: '0.000054321 AVAX' }],
-        [{header: 'Stake',body: '2000 AVAX to local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u'}],
+        {header: 'Sign', body: 'Add Validator'},
+        {header: 'Transfer', body: '3.999 AVAX to local1mg47uqd7stkvqrp57ds7m28txra45u2uzkta8n'},
+        {header: 'Validator', body: 'NodeID-NFBbbJ4qCmNaCzeW7sxErhvWqvEQMnYcN' },
+        {header: 'Start time', body: '2020-07-29 22:07:25 UTC' },
+        {header: 'End time', body: '2020-08-28 21:57:26 UTC' },
+        {header: 'Total Stake', body: '0.000054321 AVAX' },
+        {header: 'Stake',body: '2000 AVAX to local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u'},
       ], "Next", "Next");
       const sigPromise = this.ava.signTransaction(
         BIPPath.fromString(pathPrefix),
@@ -433,16 +433,16 @@ describe('Staking tests', async function () {
     const pathPrefix = "44'/9000'/0'";
     const pathSuffixes = ["0/0", "0/1", "100/100"];
     const ui = await flowMultiPrompt(this.speculos, [
-      [{header: 'Sign', body: 'Add Delegator'}],
-      [{header: 'Transfer', body: '3.999 AVAX to local1mg47uqd7stkvqrp57ds7m28txra45u2uzkta8n'}],
-      [{header: 'Validator', body: 'NodeID-NFBbbJ4qCmNaCzeW7sxErhvWqvEQMnYcN' }],
-      [{header: 'Start time', body: '2020-07-29 22:07:25 UTC' }],
-      [{header: 'End time', body: '2020-08-28 21:57:26 UTC' }],
-      [{header: 'Total Stake', body: '2000 AVAX' }],
-      [{header: 'Stake', body: '2000 AVAX to local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u'}],
-      [{header: 'Rewards To', body: 'local1mg47uqd7stkvqrp57ds7m28txra45u2uzkta8n' }],
-      [{header: 'Fee', body: '0.001 AVAX'}],
-      [{header: 'Finalize', body: 'Transaction'}],
+      {header: 'Sign', body: 'Add Delegator'},
+      {header: 'Transfer', body: '3.999 AVAX to local1mg47uqd7stkvqrp57ds7m28txra45u2uzkta8n'},
+      {header: 'Validator', body: 'NodeID-NFBbbJ4qCmNaCzeW7sxErhvWqvEQMnYcN' },
+      {header: 'Start time', body: '2020-07-29 22:07:25 UTC' },
+      {header: 'End time', body: '2020-08-28 21:57:26 UTC' },
+      {header: 'Total Stake', body: '2000 AVAX' },
+      {header: 'Stake', body: '2000 AVAX to local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u'},
+      {header: 'Rewards To', body: 'local1mg47uqd7stkvqrp57ds7m28txra45u2uzkta8n' },
+      {header: 'Fee', body: '0.001 AVAX'},
+      {header: 'Finalize', body: 'Transaction'},
     ]);
     const sigPromise = this.ava.signTransaction(
       BIPPath.fromString(pathPrefix),
@@ -516,13 +516,13 @@ describe('Staking tests', async function () {
       const pathPrefix = "44'/9000'/0'";
       const pathSuffixes = ["0/0", "0/1", "100/100"];
       const ui = await flowMultiPrompt(this.speculos, [
-        [{header: 'Sign', body: 'Add Delegator'}],
-        [{header: 'Transfer', body: '3.999 AVAX to local1mg47uqd7stkvqrp57ds7m28txra45u2uzkta8n'}],
-        [{header: 'Validator', body: 'NodeID-NFBbbJ4qCmNaCzeW7sxErhvWqvEQMnYcN' }],
-        [{header: 'Start time', body: '2020-07-29 22:07:25 UTC' }],
-        [{header: 'End time', body: '2020-08-28 21:57:26 UTC' }],
-        [{header: 'Total Stake', body: '0.000054321 AVAX' }],
-        [{header: 'Stake', body: '2000 AVAX to local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u'}],
+        {header: 'Sign', body: 'Add Delegator'},
+        {header: 'Transfer', body: '3.999 AVAX to local1mg47uqd7stkvqrp57ds7m28txra45u2uzkta8n'},
+        {header: 'Validator', body: 'NodeID-NFBbbJ4qCmNaCzeW7sxErhvWqvEQMnYcN' },
+        {header: 'Start time', body: '2020-07-29 22:07:25 UTC' },
+        {header: 'End time', body: '2020-08-28 21:57:26 UTC' },
+        {header: 'Total Stake', body: '0.000054321 AVAX' },
+        {header: 'Stake', body: '2000 AVAX to local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u'},
       ], "Next", "Next");
       const sigPromise = this.ava.signTransaction(
         BIPPath.fromString(pathPrefix),
@@ -619,18 +619,18 @@ describe('Staking tests', async function () {
     const pathPrefix = "44'/9000'/0'";
     const pathSuffixes = ["0/0", "0/1", "100/100"];
     const ui = await flowMultiPrompt(this.speculos, [
-      [{header: 'Sign', body: 'Add Validator'}],
-      [{header: 'Transfer', body: '3.999 AVAX to local1mg47uqd7stkvqrp57ds7m28txra45u2uzkta8n'}],
-      [{header: 'Validator', body: 'NodeID-NFBbbJ4qCmNaCzeW7sxErhvWqvEQMnYcN' }],
-      [{header: 'Start time', body: '2020-07-29 22:07:25 UTC' }],
-      [{header: 'End time', body: '2020-08-28 21:57:26 UTC' }],
-      [{header: 'Total Stake', body: '2000 AVAX' }],
-      [{header: 'Stake',body: '2000 AVAX to local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u'}],
-      [{header: 'Funds locked', body: '2000 AVAX until 2021-03-12 13:53:34 UTC'}],
-      [{header: 'Rewards To', body: 'local1mg47uqd7stkvqrp57ds7m28txra45u2uzkta8n' }],
-      [{header: 'Delegation Fee', body: '0.01%' }],
-      [{header: 'Fee',body: '0.001 AVAX'}],
-      [{header: 'Finalize',body: 'Transaction'}],
+      {header: 'Sign', body: 'Add Validator'},
+      {header: 'Transfer', body: '3.999 AVAX to local1mg47uqd7stkvqrp57ds7m28txra45u2uzkta8n'},
+      {header: 'Validator', body: 'NodeID-NFBbbJ4qCmNaCzeW7sxErhvWqvEQMnYcN' },
+      {header: 'Start time', body: '2020-07-29 22:07:25 UTC' },
+      {header: 'End time', body: '2020-08-28 21:57:26 UTC' },
+      {header: 'Total Stake', body: '2000 AVAX' },
+      {header: 'Stake',body: '2000 AVAX to local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u'},
+      {header: 'Funds locked', body: '2000 AVAX until 2021-03-12 13:53:34 UTC'},
+      {header: 'Rewards To', body: 'local1mg47uqd7stkvqrp57ds7m28txra45u2uzkta8n' },
+      {header: 'Delegation Fee', body: '0.01%' },
+      {header: 'Fee',body: '0.001 AVAX'},
+      {header: 'Finalize',body: 'Transaction'},
     ]);
     const sigPromise = this.ava.signTransaction(
       BIPPath.fromString(pathPrefix),
@@ -732,19 +732,19 @@ describe('Staking tests', async function () {
     const pathPrefix = "44'/9000'/0'";
     const pathSuffixes = ["0/0", "0/1", "100/100"];
     const ui = await flowMultiPrompt(this.speculos, [
-      [{header: 'Sign', body: 'Add Validator'}],
-      [{header: 'Transfer', body: '0.5 AVAX to fuji1asxdpfsmah8wqr6m8ymfwse5e4pa9fwnvudmpn'}],
-      [{header: 'Funds locked', body: '0.5 AVAX until 2021-05-31 21:28:00 UTC'}],
-      [{header: 'Validator', body: 'NodeID-MFrZFVCXPv5iCn6M9K6XduxGTYp891xXZ'}],
-      [{header: 'Start time', body: '2021-03-15 20:05:27 UTC'}],
-      [{header: 'End time', body: '2022-03-15 19:55:27 UTC'}],
-      [{header: 'Total Stake', body: '1 AVAX'}],
-      [{header: 'Stake', body: '1 AVAX to fuji1asxdpfsmah8wqr6m8ymfwse5e4pa9fwnvudmpn'}],
-      [{header: 'Funds locked', body: '1 AVAX until 2021-05-31 21:28:00 UTC'}],
-      [{header: 'Rewards To', body: 'fuji1kekq6vfg56qj5vxfhlwzmgyejfxsczqld3kdup'}],
-      [{header: 'Delegation Fee', body: '2%'}],
-      [{header: 'Fee', body: '0 AVAX'}],
-      [{header: 'Finalize', body: 'Transaction'}],
+      {header: 'Sign', body: 'Add Validator'},
+      {header: 'Transfer', body: '0.5 AVAX to fuji1asxdpfsmah8wqr6m8ymfwse5e4pa9fwnvudmpn'},
+      {header: 'Funds locked', body: '0.5 AVAX until 2021-05-31 21:28:00 UTC'},
+      {header: 'Validator', body: 'NodeID-MFrZFVCXPv5iCn6M9K6XduxGTYp891xXZ'},
+      {header: 'Start time', body: '2021-03-15 20:05:27 UTC'},
+      {header: 'End time', body: '2022-03-15 19:55:27 UTC'},
+      {header: 'Total Stake', body: '1 AVAX'},
+      {header: 'Stake', body: '1 AVAX to fuji1asxdpfsmah8wqr6m8ymfwse5e4pa9fwnvudmpn'},
+      {header: 'Funds locked', body: '1 AVAX until 2021-05-31 21:28:00 UTC'},
+      {header: 'Rewards To', body: 'fuji1kekq6vfg56qj5vxfhlwzmgyejfxsczqld3kdup'},
+      {header: 'Delegation Fee', body: '2%'},
+      {header: 'Fee', body: '0 AVAX'},
+      {header: 'Finalize', body: 'Transaction'},
     ]);
     const sigPromise = this.ava.signTransaction(
       BIPPath.fromString(pathPrefix),


### PR DESCRIPTION
## Summary
Users are prompted to confirm or deny each component of a transaction individually. This PR proposes to move to one confirmation or denial after being presented information about the whole transaction. This mimics, for example, the UX flow of the ledger-app-ethereum application.

### Testing
Have edited speculos flow tests to move to one-confirm rather than confirm-each. 

### Other Notes
Initially we are concerned with just the P-Chain related UX for LockedStakeable txns, but I included test changes for all txn confirmation flows since that's up next. We can split it out if we want.