### PR TITLE
Fix EVM parsing to work with and without prompt batching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,10 +187,10 @@ dep/%.d: %.c Makefile
 .PHONY: test test-no-nix watch watch-test
 
 watch:
-	ls Makefile src/*.c src/*.h | entr -cr make
+	ls Makefile src/*.c src/*.h | entr -cr $(MAKE)
 
 watch-test:
-	ls Makefile src/*.c src/*.h tests/*.ts tests/deps/hw-app-avalanche/src/*.ts | entr -cr make test
+	ls Makefile src/*.c src/*.h tests/*.ts tests/deps/hw-app-avalanche/src/*.ts | entr -cr $(MAKE) test
 
 test: tests/*.ts tests/package.json bin/app.elf
 	LEDGER_APP=bin/app.elf \

--- a/src/apdu_evm_sign.c
+++ b/src/apdu_evm_sign.c
@@ -169,7 +169,10 @@ static size_t next_parse(bool const is_reentry) {
         transaction_complete_prompt();
     }
 
-    PRINTF("Parse error: %d %d %d\n", rv, G.meta_state.input.consumed, G.meta_state.input.length);
+    PRINTF("Parse error: rv=%d consumed=%d length=%d\n",
+      rv,
+      G.meta_state.input.consumed,
+      G.meta_state.input.length);
     THROW(EXC_PARSE_ERROR);
 }
 

--- a/src/evm_parse.h
+++ b/src/evm_parse.h
@@ -102,12 +102,24 @@ enum txn_being_parsed_t {
   EIP1559
 };
 
+enum TxnDataSort {
+  TXN_DATA_UNSET,
+  TXN_DATA_CONTRACT_CALL_KNOWN_DEST,
+  TXN_DATA_CONTRACT_CALL_UNKNOWN_DEST,
+  TXN_DATA_DEPLOY,
+  TXN_DATA_PLAIN_TRANSFER,
+};
+
 struct EVM_RLP_txn_state {
     int state;
     uint64_t remaining;
     uint8_t len_len;
     uint8_t item_index;
-    uint8_t per_item_prompt;
+    struct {
+      uint8_t per_item_prompt;
+      enum TxnDataSort sort;
+      enum parse_rv item_rv;
+    };
     bool hasTo;
     bool hasData;
     uint64_t gasLimit;

--- a/src/parser-impl.h
+++ b/src/parser-impl.h
@@ -103,6 +103,9 @@ IMPL_FIXED(uint8_t);
 #define BREAK_IF_NOT_DONE \
     if (sub_rv != PARSE_RV_DONE) break
 
+#define RET_IF_NEED_MORE \
+    if (sub_rv == PARSE_RV_NEED_MORE) return sub_rv
+
 #define RET_IF_PROMPT_FLUSH \
     if (sub_rv == PARSE_RV_PROMPT) return sub_rv
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -7,7 +7,11 @@
 #include "network_info.h"
 
 bool should_flush(const prompt_batch_t *const prompt) {
-  return prompt->count > prompt->flushIndex;
+  bool test = prompt->count > prompt->flushIndex;
+  if (test) {
+    PRINTF("prompt buffer full; should flush!\n");
+  }
+  return test;
 }
 void set_next_batch_size(prompt_batch_t *const prompt, size_t size) {
   if(!size) size = NUM_ELEMENTS(prompt->entries);
@@ -24,8 +28,9 @@ void set_next_batch_size(prompt_batch_t *const prompt, size_t size) {
         meta->prompt.entries[meta->prompt.count].to_string = to_string_; \
         memcpy(&meta->prompt.entries[meta->prompt.count].data, data_, size_); \
         meta->prompt.count++; \
-        if (should_flush(&meta->prompt)) \
+        if (should_flush(&meta->prompt)) { \
             sub_rv = PARSE_RV_PROMPT; \
+        } \
     }
 
 #define CALL_SUBPARSER(subFieldName, subParser) { \


### PR DESCRIPTION
This generally makes the logic robust and proper as we don't know when
the queue will fill up reasoning locally. It also helps us test the new
firmware/SDK where we are having less stack space ATM and thus have no
room to batch prompts until that is fixed.